### PR TITLE
Fix the example 2 double click bug, use !== instead of !=

### DIFF
--- a/docs/react/example-2.html
+++ b/docs/react/example-2.html
@@ -73,10 +73,16 @@ const TicTacToe = BoardgameIO.Game({
 
 class TicTacToeBoard extends React.Component {
   onClick(id) {
-    if (this.props.G.winner == null) {
+    if (this.isActive(id)) {
       this.props.moves.clickCell(id);
       this.props.endTurn();
     }
+  }
+
+  isActive(id) {
+    if (this.props.G.winner !== null) return false;
+    if (this.props.G.cells[id] !== null) return false;
+    return true;
   }
 
   render() {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -135,10 +135,16 @@ import React from 'react';
 
 class TicTacToeBoard extends React.Component {
   onClick(id) {
-    if (this.props.G.winner == null) {
+    if (this.isActive(id)) {
       this.props.moves.clickCell(id);
       this.props.endTurn();
     }
+  }
+
+  isActive(id) {
+    if (this.props.G.winner !== null) return false;
+    if (this.props.G.cells[id] !== null) return false;
+    return true;
   }
 
   render() {

--- a/examples/tic-tac-toe/tic-tac-toe.js
+++ b/examples/tic-tac-toe/tic-tac-toe.js
@@ -77,7 +77,7 @@ export class Board extends React.Component {
   }
 
   isActive(id) {
-    if (this.props.G.winner != null) return false;
+    if (this.props.G.winner !== null) return false;
     if (this.props.G.cells[id] !== null) return false;
     return true;
   }


### PR DESCRIPTION
## Why?

Issue https://github.com/google/boardgame.io/issues/9

In example 2, you can skip a player's turn by clicking on an already filled cell.

## What?
- I'm assuming that the code in `example-2.html` in the script tag is what is running the game in the example docs and not `tic-tac-toe.js`
  - In the code in the script tag it's not checking if the cell `id` is null or not, it's currently checking only if there is already a winner
  - Updated to check if the current cell is not `null`
- I also updated `!=` to `!==` in `tic-tac-toe.js` to be consistent with the next line

**Note**: I've never used docsify (which I think is what's powering the docs page?) before and I was tinkering around trying to get the docs page to run locally but I was unsuccessful, so I didn't manage to test this fix for myself. However, I did go into the codepen example linked and was able to replicate the behavior noted in the bug by only checking for a winner and not checking if the currently clicked on cell is `null`. I'd be happy to test this myself too if someone could provide some insight on locally running the documentation page 👍 

Thanks!