### PR TITLE
Fix test for multi node env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,13 @@
 {
   "presets": [
-    ["es2015", { modules: false }],
+    ["es2015", { "modules": false }],
     "react",
     "stage-0"
   ],
   "env": {
+    "targets": {
+      "node": "current"
+    },
     "test": {
       "plugins": ["transform-es2015-modules-commonjs"]
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "BABEL_ENV=rollup rollup --config rollup.npm.js",
     "prepublishOnly": "generate-export-aliases",
     "postpublish": "rm -f server.js client.js game.js",
-    "postinstall": "ln -s ../packages node_modules/boardgame.io"
+    "postinstall": "ln -s ../packages/node_modules/boardgame.io"
   },
   "main": "dist/boardgameio.js",
   "unpkg": "dist/boardgameio.min.js",


### PR DESCRIPTION
Now babel uses current version of node env for transpiling.

 