### PR TITLE
Add boardgame.io install step to Tutorial.md

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -13,6 +13,7 @@ the [object spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 $ npm install -g create-react-app
 $ create-react-app game
 $ cd game
+$ npm install --save boardgame.io
 ```
 
 ## Define moves


### PR DESCRIPTION
The tutorial is great, but it was missing a bit crucial step for installing the actual `boardgame.io` framework. This PR simply adds the `npm install` step to the pre-setup 😸 