### PR TITLE
update documentations for imports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Robert Sandu
 Rifat Nabi
 Satana Charuwichitratana
 Pete Nykänen
+Philihp Busby

--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -1,25 +1,5 @@
 # Client
 
-```js
-Client({
-  // The return value of Game().
-  game: game,
-
-  // The number of players.
-  numPlayers: 2,
-
-  // The React component representing your game board.
-  board: Board,
-
-  // Set to true to enable sending move updates to the
-  // server via WebSockets.
-  multiplayer: false,
-
-  // Set to false to disable the Debug UI.
-  debug: true
-})
-```
-
 Creates a `boardgame.io` client. This is the entry point for
 the client application, and is the only call necessary on the
 client-side if you choose to roll your own move reducer.
@@ -45,7 +25,7 @@ a move or interact with the game.
 
 
 ### Arguments
-1. obj(*object*): A config object with the options shown above.
+1. obj(*object*): A config object with the options shown below.
 
 ### Returns
 (`client`): A React component that runs the app.
@@ -64,7 +44,21 @@ The component supports the following `props`:
 import Client from 'boardgame.io/client';
 
 const App = Client({
-  ...
+  // The return value of Game().
+  game: game,
+
+  // The number of players.
+  numPlayers: 2,
+
+  // The React component representing your game board.
+  board: Board,
+
+  // Set to true to enable sending move updates to the
+  // server via WebSockets.
+  multiplayer: false,
+
+  // Set to false to disable the Debug UI.
+  debug: true
 });
 
 ReactDOM.render(<App/>, document.getElementById('app'));

--- a/docs/api/Game.md
+++ b/docs/api/Game.md
@@ -1,36 +1,5 @@
 # Game
 
-```js
-Game({
-  // Initial value of G.
-  setup: (numPlayers) => ({}),
-
-  // Game moves.
-  moves: {
-    'moveName': moveFn,
-    ...
-  },
-
-  flow: {
-    // Determines when the game ends.
-    endGameIf: (G, ctx) => {
-      if (IsVictory(G)) {
-        return ctx.currentPlayer;
-      }
-    },
-    
-    phases: [
-      // TODO
-    ]
-  }
-
-  // Customized view.
-  playerView: (G, ctx, player) => {
-    return G;
-  },
-}
-```
-
 Creates a new game implementation described by the initial
 game state and the moves.
 
@@ -61,6 +30,9 @@ have `action.type` contain the name of the move, and
     is customized for a given player. See [Secret State](/secret-state) for more information.
   - `flow` (*object*): Arguments to customize the flow of the game. See
     [Phases](/phases) for more information.
+  - `phases` (*array*): Optional list of phases, within which many turns will be played. For example,
+    you might have a setup phase where players choose starting position followed by a main phase.
+    See [Phases](/phases) for more information.
 
 ### Returns
 
@@ -74,14 +46,16 @@ have `action.type` contain the name of the move, and
 ### Usage
 
 ```js
-import Game from 'boardgame.io/game';
+import { Game } from 'boardgame.io/core';
 
 const game = Game({
+  // Initial value of G.
   setup: (numPlayers) => {
     const G = {...};
     return G;
   },
 
+  // Game moves.
   moves: {
     moveWithoutArgs(G, ctx) {
       return {...G, ...};
@@ -100,8 +74,10 @@ const game = Game({
     },
   },
 
-  playerView: (G, ctx) => {
+  // View of game state which hides private information (e.g. face-down cards).
+  playerView: (G, ctx, player) => {
     return SecretsRemoved(G, ctx.currentPlayer);
   },
+
 });
 ```

--- a/docs/api/Server.md
+++ b/docs/api/Server.md
@@ -1,15 +1,5 @@
 # Server
 
-```js
-Server({
-  // The return value of Game().
-  game: game,
-
-  // The number of players.
-  numPlayers: 2,
-})
-```
-
 Creates a `boardgame.io` server. This is only required when
 `multiplayer` is set to `true` on the client. It creates a
 [Koa](http://koajs.com/) app that keeps track of the game
@@ -22,7 +12,7 @@ Notice that `game` is the same object that you also pass
 to the `Client` call.
 
 ### Arguments
-1. obj(*object*): A config object with the options shown above.
+1. obj(*object*): A config object with the options shown below.
 
 ### Returns
 (`app`): A Koa app.
@@ -30,10 +20,14 @@ to the `Client` call.
 ### Usage
 
 ```js
-const Server = require('boardgame.io/server');
+import Server from 'boardgame.io/server';
 
 const app = Server({
-  ...
+  // The return value of Game().
+  game: game,
+
+  // The number of players.
+  numPlayers: 2
 });
 
 app.listen(8000);

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -45,7 +45,7 @@ Now let's say we want the game to work in two phases:
 In order to do this, we add a `flow` section to the `Game`
 constructor (you should already be familiar with this as the location
 where you placed `endGameIf` in the
-[tutorial](http://localhost:3000/#/tutorial?id=add-victory-condition)).
+[tutorial](#/tutorial?id=add-victory-condition)).
 
 It can also contain a `phases` array, which defines different
 phases in the game. Each phase can specify a list of `allowedMoves`,


### PR DESCRIPTION
Updates a few of the documentation pages.

* In `Game` has two examples of usage. Merges them into one.
* In `Game`, switch the import from `game` to `core`.
* In `Server`, use an `import` instead of a `require`.
* Removes a link to localhost
* Red PR
  