### PR TITLE
Added test for allowEndTurnIf on SimpleFlow

### DIFF
--- a/examples/modules/tic-tac-toe/game.js
+++ b/examples/modules/tic-tac-toe/game.js
@@ -62,6 +62,10 @@ const TicTacToe = Game({
         return ctx.currentPlayer;
       }
     },
+
+    allowEndTurnIf: (G, ctx) => {
+      return ctx.currentPlayerMoves > 0;
+    },
   },
 });
 

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -84,7 +84,7 @@ test('callbacks', () => {
   expect(onPhaseEnd).toHaveBeenCalled();
 });
 
-test('movesPerTurn', () => {
+it('movesPerTurn', () => {
   {
     let flow = SimpleFlow({ movesPerTurn: 2 });
     let state = { ctx: flow.ctx(2) };
@@ -531,4 +531,43 @@ test('dispatchers', () => {
   expect(store.getState().ctx.turn).toBe(0);
   api.endTurn();
   expect(store.getState().ctx.turn).toBe(1);
+});
+
+describe('allowEndTurnIf', () => {
+  const ACCEPTED_VALUE = 'yes you can';
+  const BAD_VALUE = 'you shall not pass';
+
+  const FLOW_CONFIG = {
+    allowEndTurnIf: G => G.thingToCheck === ACCEPTED_VALUE,
+  };
+
+  it('always end turn if allowEndTurnIf is undefined', () => {
+    const flow = SimpleFlow({});
+    let state = { G: { thingToCheck: 'anything' }, ctx: flow.ctx(2) };
+    expect(state.ctx.turn).toBe(0);
+
+    state = flow.processGameEvent(state, { type: 'endTurn' });
+
+    expect(state.ctx.turn).toBe(1);
+  });
+
+  it('does not end turn if not allowed', () => {
+    const flow = SimpleFlow(FLOW_CONFIG);
+    let state = { G: { thingToCheck: BAD_VALUE }, ctx: flow.ctx(2) };
+    expect(state.ctx.turn).toBe(0);
+
+    state = flow.processGameEvent(state, { type: 'endTurn' });
+
+    expect(state.ctx.turn).toBe(0);
+  });
+
+  it('ends turn if it is allowed', () => {
+    const flow = SimpleFlow(FLOW_CONFIG);
+    let state = { G: { thingToCheck: ACCEPTED_VALUE }, ctx: flow.ctx(2) };
+    expect(state.ctx.turn).toBe(0);
+
+    state = flow.processGameEvent(state, { type: 'endTurn' });
+
+    expect(state.ctx.turn).toBe(1);
+  });
 });


### PR DESCRIPTION
A first stab at #91 to see if you think I'm going in the right direction.
- I'm only testing SimpleFlow. The fact that it has to be implemented both in simple flow and in phase flow is a code smell. Isn't simple flow just a special case of phase flow (where there is only one fixed phase)? Room for simplification here.

- I added a simple check to tic-tac-toe to force at least one move. The flow tests seem very low level. I had to resort to manually testing with tic tac toe to be confident that it worked.

- This is not covering everything yet. You can still specify an invalid move (e.g. clickCell(999) in tic-tac-toe, and endTurnIf will automatically end the turn.

- How should the system behave if endTurnIf and allowEndTurn contradict each other? (maybe that's what happening in tic-tac-toe right now.