### PR TITLE
Random deep field

### DIFF
--- a/src/core/random.js
+++ b/src/core/random.js
@@ -89,8 +89,8 @@ function deep_set(G, structuredname, newvalue) {
     return { ...G, [structuredname]: newvalue };
   }
   const [car, ...cdr] = structuredname.split('.');
-  let shuffleddata = shuffle(G[car], cdr.join('.'));
-  return { ...G, [car]: shuffleddata };
+  let G2 = deep_set(G[car], cdr.join('.'), newvalue);
+  return { ...G, [car]: G2 };
 }
 
 function deep_get(G, structuredname) {

--- a/src/core/random.test.js
+++ b/src/core/random.test.js
@@ -8,6 +8,12 @@
 
 import { randomctx, RunRandom, addrandomop, DICE, Random } from './random';
 
+function checkrandom(value, min, max) {
+  expect(value).toBeDefined();
+  expect(value).toBeGreaterThanOrEqual(min);
+  expect(value).toBeLessThanOrEqual(max);
+}
+
 test('randomctx', () => {
   let ctx = { random: { seed: 'hi there' } };
 
@@ -41,6 +47,7 @@ test('RunRandom invalid op', () => {
 
   expect(G3).toMatchObject(G);
   expect(ctx2).toMatchObject(ctx);
+  expect(G3._randomOps).toBeUndefined();
 });
 
 test('Random', () => {
@@ -71,10 +78,7 @@ test('predefined dice values', () => {
 
     let { G: G3, ctx: ctx2 } = RunRandom(G2, ctx);
     expect(ctx).not.toMatchObject(ctx2);
-    expect(G3.field1).toBeDefined();
-    expect(G3.field1).toBeGreaterThanOrEqual(1);
-    expect(G3.field1).toBeLessThanOrEqual(pair.highest);
-    expect(G3._randomOps).toBeUndefined();
+    checkrandom(G3.field1, 1, pair.highest);
   });
 });
 
@@ -87,9 +91,7 @@ test('Random.Die', () => {
 
   let { G: G3, ctx: ctx2 } = RunRandom(G2, ctx);
   expect(ctx).not.toMatchObject(ctx2);
-  expect(G3.field1).toBeDefined();
-  expect(G3.field1).toBe(74);
-  expect(G3._randomOps).toBeUndefined();
+  checkrandom(G3.field1, 74, 74);
 });
 
 test('Random.Number', () => {
@@ -101,9 +103,7 @@ test('Random.Number', () => {
 
   let { G: G3, ctx: ctx2 } = RunRandom(G2, ctx);
   expect(ctx).not.toMatchObject(ctx2);
-  expect(G3.field1).toBeDefined();
-  expect(G3.field1).toBeGreaterThanOrEqual(0);
-  expect(G3.field1).toBeLessThanOrEqual(1);
+  checkrandom(G3.field1, 0, 1);
   expect(G3._randomOps).toBeUndefined();
 });
 

--- a/src/core/random.test.js
+++ b/src/core/random.test.js
@@ -88,10 +88,14 @@ test('Random.Die', () => {
 
   // random event - die with arbitrary spot count
   const G2 = Random.Die(G, 'field1', 123);
-
   let { G: G3, ctx: ctx2 } = RunRandom(G2, ctx);
   expect(ctx).not.toMatchObject(ctx2);
   checkrandom(G3.field1, 74, 74);
+  // same with a deep field
+  const G4 = Random.Die({ a: { b: {} } }, 'a.b.c', 123);
+  let { G: G5, ctx: ctx3 } = RunRandom(G4, ctx);
+  expect(ctx).not.toMatchObject(ctx3);
+  checkrandom(G5.a.b.c, 74, 74);
 });
 
 test('Random.Number', () => {
@@ -100,11 +104,14 @@ test('Random.Number', () => {
 
   // random event - random number
   const G2 = Random.Number(G, 'field1');
-
   let { G: G3, ctx: ctx2 } = RunRandom(G2, ctx);
   expect(ctx).not.toMatchObject(ctx2);
   checkrandom(G3.field1, 0, 1);
-  expect(G3._randomOps).toBeUndefined();
+  // same with a deep field
+  const G4 = Random.Number({ a: { b: {} } }, 'a.b.c', 123);
+  let { G: G5, ctx: ctx3 } = RunRandom(G4, ctx);
+  expect(ctx).not.toMatchObject(ctx3);
+  checkrandom(G5.a.b.c, 0, 1);
 });
 
 test('Random.Shuffle', () => {

--- a/src/core/random.test.js
+++ b/src/core/random.test.js
@@ -121,3 +121,21 @@ test('Random.Shuffle', () => {
   expect(G3.tiles.sort()).toEqual(initialTiles);
   expect(ctx).not.toMatchObject(ctx2);
 });
+
+test('Random.Shuffle works on a nested attribute', () => {
+  let ctx = { random: { seed: 'some_predetermined_seed' } };
+  const tiles = ['A', 'B', 'C', 'D', 'E'];
+  let G = {
+    players: {
+      0: tiles,
+      1: tiles,
+    },
+  };
+
+  let G2 = Random.Shuffle(G, 'players.1');
+  let { G: G3 } = RunRandom(G2, ctx);
+  expect(G.players['0']).toMatchObject(tiles);
+  expect(G.players['1']).toMatchObject(tiles); // this was the tricky one :(
+  expect(G3.players['0']).toMatchObject(tiles);
+  expect(G3.players['1']).not.toMatchObject(tiles);
+});


### PR DESCRIPTION
Fixes #117 

* Accessing an object is now done inside two functions `deep_set` and `deep_get`.
* I've added @philihp s test unmodified
* Random numbers and dice support setting deep fields also.