### PR TITLE
Debug UI: fixes related to errors in arguments

### DIFF
--- a/src/client/debug/debug.css
+++ b/src/client/debug/debug.css
@@ -47,6 +47,11 @@
   font-weight: bold;
 }
 
+.debug-ui .move-error {
+  color: #a00;
+  font-weight: bold;
+}
+
 .debug-ui .arg-field {
   outline: none;
   font-family: monospace;

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -26,9 +26,6 @@ export class DebugMove extends React.Component {
     name: PropTypes.string.isRequired,
     shortcut: PropTypes.string.isRequired,
     fn: PropTypes.func.isRequired,
-    active: PropTypes.bool,
-    activate: PropTypes.func,
-    deactivate: PropTypes.func,
   };
 
   state = {

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -38,29 +38,19 @@ export class DebugMove extends React.Component {
     this.props.activate();
   };
 
-  getArg(arg) {
-    try {
-      return new Function('return ' + arg)();
-    } catch (e) {
-      return undefined;
-    }
-  }
-
   onSubmit = () => {
-    let argArray = [];
     const value = this.span.innerText;
+    let error = '';
 
-    if (value && value.length) {
-      const args = value.split(',');
-      for (const arg of args) {
-        argArray.push(this.getArg(arg));
-      }
+    try {
+      let argArray = new Function(`return [${value}]`)();
+      this.props.fn.apply(this, argArray);
+    } catch (e) {
+      error = '' + e;
     }
-
-    this.props.fn.apply(this, argArray);
 
     this.setState({
-      error: '',
+      error,
       focus: false,
       enterArg: false,
     });

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -24,6 +24,7 @@ import './debug.css';
 export class DebugMove extends React.Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
+    shortcut: PropTypes.string.isRequired,
     fn: PropTypes.func.isRequired,
     active: PropTypes.bool,
     activate: PropTypes.func,
@@ -34,12 +35,7 @@ export class DebugMove extends React.Component {
     error: '',
   };
 
-  onClick = () => {
-    this.props.activate();
-  };
-
-  onSubmit = () => {
-    const value = this.span.innerText;
+  onSubmit = value => {
     let error = '';
 
     try {
@@ -54,24 +50,29 @@ export class DebugMove extends React.Component {
       focus: false,
       enterArg: false,
     });
-
-    this.span.innerText = '';
-
-    if (this.props.deactivate) {
-      this.props.deactivate();
-    }
   };
 
-  onKeyDown = e => {
-    if (e.key == 'Enter') {
-      e.preventDefault();
-      this.onSubmit();
-    }
+  render() {
+    return (
+      <div>
+        <KeyboardShortcut value={this.props.shortcut}>
+          <DebugMoveArgField name={this.props.name} onSubmit={this.onSubmit} />
+        </KeyboardShortcut>
+        {this.state.error ? (
+          <span className="move-error">{this.state.error}</span>
+        ) : null}
+      </div>
+    );
+  }
+}
 
-    if (e.key == 'Escape') {
-      e.preventDefault();
-      this.props.deactivate();
-    }
+export class DebugMoveArgField extends React.Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    active: PropTypes.bool,
+    activate: PropTypes.func,
+    deactivate: PropTypes.func,
   };
 
   componentDidUpdate() {
@@ -82,18 +83,33 @@ export class DebugMove extends React.Component {
     }
   }
 
+  onKeyDown = e => {
+    if (e.key == 'Enter') {
+      e.preventDefault();
+      const value = this.span.innerText;
+      this.props.onSubmit(value);
+      this.span.innerText = '';
+      this.props.deactivate();
+    }
+
+    if (e.key == 'Escape') {
+      e.preventDefault();
+      this.props.deactivate();
+    }
+  };
+
   render() {
     let className = 'move';
     if (this.props.active) className += ' active';
     return (
-      <div className={className} onClick={this.onClick}>
+      <div className={className} onClick={this.props.activate}>
         {this.props.name}
         (<span
           ref={r => {
             this.span = r;
           }}
           className="arg-field"
-          onBlur={() => this.props.deactivate()}
+          onBlur={this.props.deactivate}
           onKeyDown={this.onKeyDown}
           contentEditable
         />)
@@ -344,9 +360,7 @@ export class Debug extends React.Component {
       const fn = this.props.moves[name];
       const shortcut = this.shortcuts[name];
       moves.push(
-        <KeyboardShortcut key={name} value={shortcut}>
-          <DebugMove name={name} fn={fn} />
-        </KeyboardShortcut>
+        <DebugMove key={name} name={name} fn={fn} shortcut={shortcut} />
       );
     }
 
@@ -355,9 +369,7 @@ export class Debug extends React.Component {
       const fn = this.props.events[name];
       const shortcut = this.shortcuts[name];
       events.push(
-        <KeyboardShortcut key={name} value={shortcut}>
-          <DebugMove name={name} fn={fn} />
-        </KeyboardShortcut>
+        <DebugMove key={name} name={name} fn={fn} shortcut={shortcut} />
       );
     }
 

--- a/src/client/debug/debug.test.js
+++ b/src/client/debug/debug.test.js
@@ -9,7 +9,12 @@
 import React from 'react';
 import { restore } from '../../core/action-creators';
 import { createStore } from 'redux';
-import { Debug, DebugMove, KeyboardShortcut } from './debug.js';
+import {
+  Debug,
+  DebugMove,
+  DebugMoveArgField,
+  KeyboardShortcut,
+} from './debug.js';
 import Mousetrap from 'mousetrap';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -76,15 +81,16 @@ test('basic', () => {
 
 test('parse arguments', () => {
   const spy = jest.fn();
-  const root = Enzyme.mount(<DebugMove name="test" fn={spy} />);
+  const root = Enzyme.mount(<DebugMove name="test" fn={spy} shortcut="e" />);
 
-  root.instance().span.innerText = '1,2';
-  root.instance().onSubmit();
+  root.instance().onSubmit('1,2');
   expect(spy.mock.calls[0]).toEqual([1, 2]);
 
-  root.instance().span.innerText = '3, unknown, 4';
-  root.instance().onSubmit();
-  expect(spy.mock.calls.length).toEqual(1);
+  root.instance().onSubmit('["a", "b"], ","');
+  expect(spy.mock.calls[1]).toEqual([['a', 'b'], ',']);
+
+  root.instance().onSubmit('3, unknown, 4');
+  expect(spy.mock.calls.length).toEqual(2);
   expect(root.state().error).toEqual('ReferenceError: unknown is not defined');
 });
 
@@ -97,18 +103,14 @@ test('KeyboardShortcut', () => {
 
 test('DebugMove', () => {
   const fn = jest.fn();
-  const root = Enzyme.mount(
-    <KeyboardShortcut value="e">
-      <DebugMove fn={fn} name="endTurn" />
-    </KeyboardShortcut>
-  );
+  const root = Enzyme.mount(<DebugMove fn={fn} name="endTurn" shortcut="e" />);
 
-  root.find(DebugMove).simulate('click');
+  root.simulate('click');
   root.find('.move span').simulate('keyDown', { key: 'Enter' });
 
   expect(fn.mock.calls.length).toBe(1);
 
-  root.find(DebugMove).simulate('click');
+  root.simulate('click');
   root.find('.move span').simulate('keydown', { key: '1' });
   root.find('.move span').simulate('keydown', { key: 'Enter' });
 
@@ -118,18 +120,18 @@ test('DebugMove', () => {
 test('escape blurs DebugMove', () => {
   const root = Enzyme.mount(
     <KeyboardShortcut value="e">
-      <DebugMove fn={jest.fn()} name="endTurn" />
+      <DebugMoveArgField onSubmit={jest.fn()} name="endTurn" />
     </KeyboardShortcut>
   );
 
   expect(root.state().active).toBe(false);
 
-  root.find(DebugMove).simulate('click');
+  root.find(DebugMoveArgField).simulate('click');
   expect(root.state().active).toBe(true);
   root.find('.move span').simulate('keydown', { key: 'Escape' });
   expect(root.state().active).toBe(false);
 
-  root.find(DebugMove).simulate('click');
+  root.find(DebugMoveArgField).simulate('click');
   expect(root.state().active).toBe(true);
   root.find('.move span').simulate('blur');
   expect(root.state().active).toBe(false);

--- a/src/client/debug/debug.test.js
+++ b/src/client/debug/debug.test.js
@@ -84,7 +84,8 @@ test('parse arguments', () => {
 
   root.instance().span.innerText = '3, unknown, 4';
   root.instance().onSubmit();
-  expect(spy.mock.calls[1]).toEqual([3, undefined, 4]);
+  expect(spy.mock.calls.length).toEqual(1);
+  expect(root.state().error).toEqual('ReferenceError: unknown is not defined');
 });
 
 test('KeyboardShortcut', () => {


### PR DESCRIPTION
Hey,
the behaviour of the debug UI is pretty confusing.
Calling a move/event function with `[1, 2, 3]` results in a call with arguments `undefined, 2, undefined`.

This changes the arguments to all be evaluated in one call, thus `argText.split(',')` is no longer needed. As a result the test `3, unknown, 4` will error instead of evaluating to `3, undefined, 4`. I'd say this behaviour is sensible. I've changed the test accordingly.

This also implements basic error reporting.