### PR TITLE
Fix a typo in example

### DIFF
--- a/examples/modules/liars-dice/components/multiview.js
+++ b/examples/modules/liars-dice/components/multiview.js
@@ -32,7 +32,7 @@ const Multiview = () => (
         <App gameID="liarsDice" playerID="1" />
       </div>
       <div className="run">
-        &lt;App playerID=&quot;1&quot;/&gt;
+        &lt;App playerID=&quot;2&quot;/&gt;
         <App gameID="liarsDice" playerID="2" />
       </div>
       <div className="run">


### PR DESCRIPTION
The description in the example for player 2 should be 
```
<App playerID="2"/>
```
Instead of 
```
<App playerID="1"/>
```