### PR TITLE
Fix random setup

### DIFF
--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -24,9 +24,7 @@ export function createGameReducer({ game, numPlayers, multiplayer }) {
 
   // need to init PRNGState here, otherwise calls to
   // Random inside setup() are using undefined
-  if (game !== undefined) {
-    PRNGState.set(game.seed);
-  }
+  PRNGState.set(game.seed);
 
   const initial = {
     // User managed state.

--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -22,9 +22,9 @@ export function createGameReducer({ game, numPlayers, multiplayer }) {
     numPlayers = 2;
   }
 
-  // need to init PRNGState here, otherwise calls to
-  // Random inside setup() are using undefined
-  PRNGState.set(game.seed);
+  // Need to init PRNGState here, otherwise calls to
+  // Random inside setup() are using undefined.
+  PRNGState.set({ seed: game.seed });
 
   const initial = {
     // User managed state.
@@ -54,7 +54,7 @@ export function createGameReducer({ game, numPlayers, multiplayer }) {
   };
 
   // Initialize PRNG seed.
-  initial.ctx._random = { seed: PRNGState.get() };
+  initial.ctx._random = PRNGState.get();
 
   const state = game.flow.init({ G: initial.G, ctx: initial.ctx });
 

--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -22,6 +22,12 @@ export function createGameReducer({ game, numPlayers, multiplayer }) {
     numPlayers = 2;
   }
 
+  // need to init PRNGState here, otherwise calls to
+  // Random inside setup() are using undefined
+  if (game !== undefined) {
+    PRNGState.set(game.seed);
+  }
+
   const initial = {
     // User managed state.
     G: game.setup(numPlayers),
@@ -50,7 +56,7 @@ export function createGameReducer({ game, numPlayers, multiplayer }) {
   };
 
   // Initialize PRNG seed.
-  initial.ctx._random = { seed: game.seed };
+  initial.ctx._random = { seed: PRNGState.get() };
 
   const state = game.flow.init({ G: initial.G, ctx: initial.ctx });
 

--- a/src/core/reducer.test.js
+++ b/src/core/reducer.test.js
@@ -154,12 +154,30 @@ test('log', () => {
 });
 
 test('using Random inside setup()', () => {
-  const game = Game({
-    setup: () => Random.Shuffle([...Array(5).keys()]),
+  const game1 = Game({
+    seed: 'seed1',
+    setup: () => ({ n: Random.D6() }),
   });
 
-  const reducer = createGameReducer({ game });
+  const game2 = Game({
+    seed: 'seed2',
+    setup: () => ({ n: Random.D6() }),
+  });
 
-  const state = reducer(undefined, makeMove('moveA'));
-  expect(state.G).toMatchObject([2, 3, 0, 1, 4]);
+  const game3 = Game({
+    seed: 'seed2',
+    setup: () => ({ n: Random.D6() }),
+  });
+
+  const reducer1 = createGameReducer({ game: game1 });
+  const state1 = reducer1(undefined, makeMove());
+
+  const reducer2 = createGameReducer({ game: game2 });
+  const state2 = reducer2(undefined, makeMove());
+
+  const reducer3 = createGameReducer({ game: game3 });
+  const state3 = reducer3(undefined, makeMove());
+
+  expect(state1.G.n).not.toBe(state2.G.n);
+  expect(state2.G.n).toBe(state3.G.n);
 });

--- a/src/core/reducer.test.js
+++ b/src/core/reducer.test.js
@@ -9,6 +9,7 @@
 import Game from './game';
 import { createGameReducer } from './reducer';
 import { makeMove, gameEvent, restore } from './action-creators';
+import { Random } from './random';
 
 const game = Game({
   moves: {
@@ -150,4 +151,15 @@ test('log', () => {
   expect(state.log).toEqual([actionA, actionB]);
   state = reducer(state, actionC);
   expect(state.log).toEqual([actionA, actionB, actionC.payload]);
+});
+
+test('using Random inside setup()', () => {
+  const game = Game({
+    setup: () => Random.Shuffle([...Array(5).keys()]),
+  });
+  const reducer = createGameReducer({ game });
+
+  const state = reducer(undefined, makeMove('moveA'));
+  console.log(JSON.stringify(state, null, 3));
+  expect(state.G).toMatchObject([2, 3, 0, 1, 4]);
 });

--- a/src/core/reducer.test.js
+++ b/src/core/reducer.test.js
@@ -157,9 +157,9 @@ test('using Random inside setup()', () => {
   const game = Game({
     setup: () => Random.Shuffle([...Array(5).keys()]),
   });
+
   const reducer = createGameReducer({ game });
 
   const state = reducer(undefined, makeMove('moveA'));
-  console.log(JSON.stringify(state, null, 3));
   expect(state.G).toMatchObject([2, 3, 0, 1, 4]);
 });


### PR DESCRIPTION
Fixes #133 

@nicolodavis Please check whether `initial` is correctly initialized. `initial.ctx.random` now contains `PRNGState.get()` after `setup` has been evaluated. The true initial state would be not running anything (no `setup` either), and then having one state that evaluates `setup`.
 
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).

