### PR TITLE
fix display of log with phased game

### DIFF
--- a/src/client/log/log.js
+++ b/src/client/log/log.js
@@ -58,7 +58,7 @@ export class GameLog extends React.Component {
       const item = state.log[i];
       if (
         (item.type == Actions.GAME_EVENT && item.payload.type == 'endTurn') ||
-        item.type == 'endTurn'
+        ['endTurn', 'endPhase'].includes(item.type)
       ) {
         turnToLogIndex[turns.length] = i;
         turns.push(currentTurn);


### PR DESCRIPTION
I think the debug log pane is busted for games with multiple phases. You can demo this if you look up the phases game in examples http://localhost:8000/#/phases and turn on the log window. This quick fix sort of gets it operational, but it still gets messed up if you mouseover past history. I'm kind of drunk sorry ballmer peak doesn't help with sentence structure.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
