### PR TITLE
allow optional redux enhancer

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,6 +12,7 @@
   * [Secret State](secret-state.md)
   * [Randomness](random.md)
   * [Undo / Redo](undo.md)
+  * [Debugging](debugging.md)
 
 * API Reference
 

--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -27,6 +27,9 @@ The `Board` component will receive the following as `props`:
 
 8. `isConnected`: `true` if connection to the server is active.
 
+9. `enhancer`: An optional Redux store enhancer, passed along to
+   the internals store.
+
 ### Arguments
 
 1. obj(_object_): A config object with the options shown below.

--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -28,7 +28,8 @@ The `Board` component will receive the following as `props`:
 8. `isConnected`: `true` if connection to the server is active.
 
 9. `enhancer`: An optional Redux store enhancer, passed along to
-   the internals store.
+   the internals store. See the [Debugging](debugging.md) section
+   for more details.
 
 ### Arguments
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,35 @@
+## Debugging Internals
+
+It may help to debug the internal Redux store. In order to do so, you can
+pass along a Redux store enhancer with your client. For example,
+
+```js
+import logger from 'redux-logger';
+import { applyMiddleware } from 'redux';
+
+export default Client({
+  game,
+  numPlayers: 1,
+  board: Board,
+  enhancer: applyMiddleware(logger),
+});
+```
+
+Doing so will console.log on state changes. This can also hook into the [Chrome Redux DevTools](http://extension.remotedev.io/) browser extension as such
+
+```js
+...
+  enhancer: window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())
+...
+```
+
+or both
+
+```js
+...
+  enhancer: compose(
+    applyMiddleware(logger),
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())
+  )
+...
+```

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,4 +1,4 @@
-## Debugging Internals
+# Debugging
 
 It may help to debug the internal Redux store. In order to do so, you can
 pass along a Redux store enhancer with your client. For example,
@@ -15,21 +15,26 @@ export default Client({
 });
 ```
 
-Doing so will console.log on state changes. This can also hook into the [Chrome Redux DevTools](http://extension.remotedev.io/) browser extension as such
+Doing so will console.log on state changes. This can also hook into the [Chrome Redux DevTools](http://extension.remotedev.io/) browser extension like this:
 
 ```js
-...
+export default Client({
+  ...
   enhancer: window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())
-...
+}
 ```
 
 or both
 
 ```js
-...
+import logger from 'redux-logger';
+import { applyMiddleware, compose } from 'redux';
+
+export default Client({
+  ...
   enhancer: compose(
     applyMiddleware(logger),
     window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())
   )
-...
+})
 ```

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -51,7 +51,7 @@ export function createMoveDispatchers(moveNames, store, playerID) {
  * Implementation of Client (see below).
  */
 class _ClientImpl {
-  constructor({ game, numPlayers, multiplayer, gameID, playerID }) {
+  constructor({ game, numPlayers, multiplayer, gameID, playerID, enhancer }) {
     this.game = game;
     this.playerID = playerID;
     this.gameID = gameID;
@@ -80,9 +80,9 @@ class _ClientImpl {
         numPlayers,
         server,
       });
-      this.store = this.multiplayerClient.createStore(GameReducer);
+      this.store = this.multiplayerClient.createStore(GameReducer, enhancer);
     } else {
-      this.store = createStore(GameReducer);
+      this.store = createStore(GameReducer, enhancer);
     }
 
     this.createDispatchers();

--- a/src/client/client.test.js
+++ b/src/client/client.test.js
@@ -44,6 +44,29 @@ test('multiplayer server set when provided', () => {
   expect(client.multiplayerClient.socket.io.engine.port).toEqual(port);
 });
 
+test('accepts enhancer for store', () => {
+  let spyDispatcher;
+  const spyEnhancer = vanillaCreateStore => (...args) => {
+    const vanillaStore = vanillaCreateStore(...args);
+    return {
+      ...vanillaStore,
+      dispatch: (spyDispatcher = jest.fn(vanillaStore.dispatch)),
+    };
+  };
+  const client = Client({
+    game: Game({
+      moves: {
+        A: (G, ctx, arg) => ({ arg }),
+      },
+    }),
+    enhancer: spyEnhancer,
+  });
+
+  expect(spyDispatcher.mock.calls.length).toBe(0);
+  client.moves.A(42);
+  expect(spyDispatcher.mock.calls.length).toBe(1);
+});
+
 test('event dispatchers', () => {
   {
     const game = Game({});

--- a/src/client/multiplayer/multiplayer.js
+++ b/src/client/multiplayer/multiplayer.js
@@ -11,6 +11,7 @@ import * as ActionCreators from '../../core/action-creators';
 import { createStore, applyMiddleware, compose } from 'redux';
 import io from 'socket.io-client';
 
+// The actions that are sent across the network.
 const whiteListedActions = new Set([MAKE_MOVE, GAME_EVENT]);
 
 /**

--- a/src/client/multiplayer/multiplayer.js
+++ b/src/client/multiplayer/multiplayer.js
@@ -8,8 +8,10 @@
 
 import { MAKE_MOVE, GAME_EVENT } from '../../core/action-types';
 import * as ActionCreators from '../../core/action-creators';
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import io from 'socket.io-client';
+
+const whiteListedActions = new Set([MAKE_MOVE, GAME_EVENT]);
 
 /**
  * Multiplayer
@@ -42,15 +44,14 @@ export class Multiplayer {
    * Creates a Redux store with some middleware that sends actions
    * to the server whenever they are dispatched.
    * @param {function} reducer - The game reducer.
+   * @param {function} enhancer - optional enhancer to apply to Redux store
    */
-  createStore(reducer) {
+  createStore(reducer, enhancer) {
     this.store = null;
-
-    const whiteListedActions = new Set([MAKE_MOVE, GAME_EVENT]);
 
     // Redux middleware to emit a message on a socket
     // whenever an action is dispatched.
-    const SocketUpdate = ({ getState }) => next => action => {
+    const SocketEnhancer = applyMiddleware(({ getState }) => next => action => {
       const state = getState();
       const result = next(action);
 
@@ -65,9 +66,10 @@ export class Multiplayer {
       }
 
       return result;
-    };
+    });
 
-    this.store = createStore(reducer, applyMiddleware(SocketUpdate));
+    enhancer = enhancer ? compose(enhancer, SocketEnhancer) : SocketEnhancer;
+    this.store = createStore(reducer, enhancer);
 
     return this.store;
   }

--- a/src/client/multiplayer/multiplayer.test.js
+++ b/src/client/multiplayer/multiplayer.test.js
@@ -8,6 +8,7 @@
 
 import { Multiplayer } from './multiplayer';
 import Game from '../../core/game';
+import { makeMove } from '../../core/action-creators';
 import { createGameReducer } from '../../core/reducer';
 import * as ActionCreators from '../../core/action-creators';
 
@@ -135,4 +136,29 @@ test('game server is set when provided', () => {
   m2.connect();
   expect(m2.socket.io.engine.hostname).not.toEqual(hostname);
   expect(m2.socket.io.engine.port).not.toEqual(port);
+});
+
+test('game server accepts enhanced store', () => {
+  let spyDispatcher;
+  const spyEnhancer = vanillaCreateStore => (...args) => {
+    const vanillaStore = vanillaCreateStore(...args);
+    return {
+      ...vanillaStore,
+      dispatch: (spyDispatcher = jest.fn(vanillaStore.dispatch)),
+    };
+  };
+
+  const mockSocket = new MockSocket();
+  const m = new Multiplayer({ socket: mockSocket });
+  m.connect();
+  const game = Game({
+    moves: {
+      A: (G, ctx, arg) => ({ arg }),
+    },
+  });
+  const store = m.createStore(createGameReducer({ game }), spyEnhancer);
+  // console.log(spyDispatcher.mock);
+  expect(spyDispatcher.mock.calls.length).toBe(0);
+  store.dispatch(makeMove('A', {}));
+  expect(spyDispatcher.mock.calls.length).toBe(1);
 });

--- a/src/client/react.js
+++ b/src/client/react.js
@@ -23,13 +23,21 @@ import { Client as RawClient } from './client';
  *                                  to make a multiplayer client. The second
  *                                  syntax specifies a non-default socket server.
  * @param {...object} debug - Enables the Debug UI.
+ * @param {...object} enhancer - Optional enhancer to send to the Redux store
  *
  * Returns:
  *   A React component that wraps board and provides an
  *   API through props for it to interact with the framework
  *   and dispatch actions such as MAKE_MOVE and END_TURN.
  */
-export function Client({ game, numPlayers, board, multiplayer, debug }) {
+export function Client({
+  game,
+  numPlayers,
+  board,
+  multiplayer,
+  debug,
+  enhancer,
+}) {
   if (debug === undefined) debug = true;
 
   /*
@@ -65,6 +73,7 @@ export function Client({ game, numPlayers, board, multiplayer, debug }) {
         multiplayer,
         gameID: props.gameID,
         playerID: props.playerID,
+        enhancer,
       });
 
       this.client.subscribe(() => this.forceUpdate());


### PR DESCRIPTION
Adds an optional param to a Client which allows the user to hook into the Redux store with an enhancer or middleware.

The main motivation for this is to hook into it with [`redux-logger`](https://github.com/evgenyrodionov/redux-logger) or [Redux Devtools](http://extension.remotedev.io/), and is documented in an additional page.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
