### PR TITLE
Enabling server-side-rendering for boardgame.io (fixes #22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2715,11 +2715,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base16": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA="
-    },
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
@@ -3421,6 +3416,8 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
       "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "good-listener": "1.2.2",
         "select": "1.1.2",
@@ -4218,7 +4215,9 @@
     "delegate": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.3.tgz",
-      "integrity": "sha1-moJRp3fXAl+qVXN7w7BxdCEnqf0="
+      "integrity": "sha1-moJRp3fXAl+qVXN7w7BxdCEnqf0=",
+      "dev": true,
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -5582,14 +5581,6 @@
         "bser": "2.0.0"
       }
     },
-    "fbemitter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
-      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
-      "requires": {
-        "fbjs": "0.8.15"
-      }
-    },
     "fbjs": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.15.tgz",
@@ -5753,15 +5744,6 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
-    },
-    "flux": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-3.1.3.tgz",
-      "integrity": "sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=",
-      "requires": {
-        "fbemitter": "2.1.1",
-        "fbjs": "0.8.15"
-      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -6930,6 +6912,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "delegate": "3.1.3"
       }
@@ -10208,11 +10192,6 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
-    "lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -10224,11 +10203,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
-    },
-    "lodash.flow": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -12451,11 +12425,6 @@
       "integrity": "sha1-mpVopa9+ZXuEYqbp1TKHQ1YM7/Y=",
       "dev": true
     },
-    "pure-color": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-      "integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4="
-    },
     "q": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
@@ -12683,17 +12652,6 @@
         }
       }
     },
-    "react-base16-styling": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.5.3.tgz",
-      "integrity": "sha1-OFjyTpxN2MvT9wLz901YHKKRcmk=",
-      "requires": {
-        "base16": "1.0.0",
-        "lodash.curry": "4.1.1",
-        "lodash.flow": "3.5.0",
-        "pure-color": "1.3.0"
-      }
-    },
     "react-color": {
       "version": "2.13.8",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.13.8.tgz",
@@ -12824,17 +12782,6 @@
         "is-dom": "1.0.9"
       }
     },
-    "react-json-view": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.13.0.tgz",
-      "integrity": "sha512-CPIVlqPl/xHsZ50cQSNKrv+ttmvS7rbPtEyljevo16Szfd5JcMwPS9ItQBldOiZ/CqWnq6yQlQwfQcXKB0tD4g==",
-      "requires": {
-        "clipboard": "1.7.1",
-        "flux": "3.1.3",
-        "react-base16-styling": "0.5.3",
-        "react-textarea-autosize": "5.1.0"
-      }
-    },
     "react-modal": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.5.tgz",
@@ -12952,14 +12899,6 @@
             "ua-parser-js": "0.7.14"
           }
         }
-      }
-    },
-    "react-textarea-autosize": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-5.1.0.tgz",
-      "integrity": "sha1-/7+BZPziF8eUQ8HBfe33MFkt8iQ=",
-      "requires": {
-        "prop-types": "15.5.10"
       }
     },
     "react-transition-group": {
@@ -13819,7 +13758,9 @@
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
     },
     "semver": {
       "version": "5.4.1",
@@ -14688,7 +14629,9 @@
     "tiny-emitter": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
+      "dev": true,
+      "optional": true
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "mongodb": "^3.0.3",
     "mousetrap": "^1.6.1",
     "prop-types": "^15.5.10",
-    "react-json-view": "^1.13.0",
     "redux": "^3.7.2",
     "socket.io": "^2.0.3"
   },

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -424,14 +424,14 @@ export class Debug extends React.Component {
 
             <section>
               <pre>
-                &ldquo;G&rdquo;:{' '}
+                <strong>G</strong>:{' '}
                 {JSON.stringify(this.props.gamestate.G, null, 2)}
               </pre>
             </section>
 
             <section>
               <pre>
-                &ldquo;ctx&rdquo;:{' '}
+                <strong>ctx</strong>:{' '}
                 {JSON.stringify(this.props.gamestate.ctx, null, 2)}
               </pre>
             </section>

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import ReactJson from 'react-json-view';
 import PropTypes from 'prop-types';
 import Mousetrap from 'mousetrap';
 import { GameLog } from '../log/log';
@@ -424,21 +423,17 @@ export class Debug extends React.Component {
             <h3>state</h3>
 
             <section>
-              <ReactJson
-                src={this.props.gamestate.G}
-                name="G"
-                enableClipboard={false}
-                displayDataTypes={false}
-              />
+              <pre>
+                &ldquo;G&rdquo;:{' '}
+                {JSON.stringify(this.props.gamestate.G, null, 2)}
+              </pre>
             </section>
 
             <section>
-              <ReactJson
-                src={this.props.gamestate.ctx}
-                name="ctx"
-                enableClipboard={false}
-                displayDataTypes={false}
-              />
+              <pre>
+                &ldquo;ctx&rdquo;:{' '}
+                {JSON.stringify(this.props.gamestate.ctx, null, 2)}
+              </pre>
             </section>
           </span>
         )}

--- a/src/client/react.js
+++ b/src/client/react.js
@@ -80,7 +80,9 @@ export function Client({ game, numPlayers, board, multiplayer, debug }) {
     }
 
     componentWillMount() {
-      this.client.connect();
+      if (typeof window !== 'undefined') {
+        this.client.connect();
+      }
     }
 
     render() {

--- a/src/client/react.ssr.test.js
+++ b/src/client/react.ssr.test.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment node
+ */
+
+import React from 'react';
+import { Client } from './react';
+import Game from '../core/game';
+import ReactDOMServer from 'react-dom/server';
+
+class TestBoard extends React.Component {
+  render() {
+    return <div id="board">Board</div>;
+  }
+}
+
+test('board is rendered - ssr', () => {
+  const Board = Client({
+    game: Game({}),
+    board: TestBoard,
+    multiplayer: true,
+  });
+  let ssrRender = ReactDOMServer.renderToString(<Board />);
+  expect(ssrRender).toContain('debug-ui');
+});


### PR DESCRIPTION
Fixes #22 !!!

- Creates test for making sure we are not throwing errors when doing SSR. (Cool stuff that jest can emulate node!)
- Replaces react-json-view with simple \<pre\> and JSON (react-json-view throws "window is not defined")
- Avoid establishing socket.io connection to the server if you are, er, executing on the server. 