### PR TITLE
Run endPhase event (analogue to endTurn) when game ends

### DIFF
--- a/src/client/multiplayer/multiplayer.test.js
+++ b/src/client/multiplayer/multiplayer.test.js
@@ -26,6 +26,11 @@ class MockSocket {
   }
 }
 
+test('Multiplayer defaults', () => {
+  const m = new Multiplayer();
+  m.callback();
+});
+
 test('update gameID / playerID', () => {
   const m = new Multiplayer();
   m.updateGameID('test');

--- a/src/client/multiplayer/multiplayer.test.js
+++ b/src/client/multiplayer/multiplayer.test.js
@@ -28,6 +28,7 @@ class MockSocket {
 
 test('Multiplayer defaults', () => {
   const m = new Multiplayer();
+  expect(typeof m.callback).toBe('function');
   m.callback();
 });
 

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -435,19 +435,19 @@ export function FlowWithPhases({
       state = dispatch(state, { type: 'endTurn', playerID: action.playerID });
     }
 
-    // End the game automatically if endGameIf returns.
-    if (gameover !== undefined) {
-      return { ...state, ctx: { ...state.ctx, gameover } };
-    }
-
     // End the phase automatically if endPhaseIf is true.
     const end = conf.endPhaseIf(state.G, state.ctx);
-    if (end) {
+    if (end || gameover !== undefined) {
       state = dispatch(state, {
         type: 'endPhase',
         args: [end],
         playerID: action.playerID,
       });
+    }
+
+    // End the game automatically if endGameIf returns.
+    if (gameover !== undefined) {
+      return { ...state, ctx: { ...state.ctx, gameover } };
     }
 
     // Update undo / redo state.

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -15,6 +15,14 @@ test('Flow', () => {
   const flow = Flow({});
   const state = {};
   expect(flow.processGameEvent(state, { type: 'unknown' })).toBe(state);
+
+  // Check defaults of all arguments
+  expect(flow.ctx()).toMatchObject({});
+  expect(flow.eventNames.length).toBe(0);
+  expect(flow.init({ a: 5 })).toMatchObject({ a: 5 });
+  expect(flow.validator({}, {}, undefined)).toBe(true);
+  expect(flow.processMove({ b: 6 })).toMatchObject({ b: 6 });
+  expect(flow.optimisticUpdate()).toBe(true);
 });
 
 test('FlowWithPhases', () => {


### PR DESCRIPTION
This PR changes `FlowWithPhases` `processMove` by also running the _endPhase_ event when the game ends. I've run across this while reading the code.

The intention is to streamline the flow of events. Currently, when the game ends, only the _endTurn_ event is fired. However, I see no reason not to run the _endPhase_ event also.

Also, since I was on it, I've added some assertions to bring coverage to full 100%. If that was really necessary or not, I don't know. 

#### Checklist

* [ x] Use a separate branch in your local repo (not `master`).
* [ x] Test coverage is 100% (or you have a story for why it's ok).
