### PR TITLE
Fix bug that was ending phase incorrectly

### DIFF
--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -717,3 +717,31 @@ test('undo / redo restricted by undoableMoves', () => {
   state = reducer(state, undo());
   expect(state.G).toEqual({});
 });
+
+test('endPhaseOnMove', () => {
+  let endPhaseACount = 0;
+  let endPhaseBCount = 0;
+  const onMove = () => ({ A: true });
+
+  let flow = FlowWithPhases({
+    onMove,
+    phases: [
+      {
+        name: 'A',
+        endTurnIf: () => true,
+        endPhaseIf: () => true,
+        onPhaseEnd: () => ++endPhaseACount,
+      },
+      {
+        name: 'B',
+        endTurnIf: () => false,
+        endPhaseIf: () => false,
+        onPhaseEnd: () => ++endPhaseBCount,
+      },
+    ],
+  });
+  const state = { G: {}, ctx: flow.ctx(2) };
+  flow.processMove(state, { payload: {} });
+  expect(endPhaseACount).toEqual(1);
+  expect(endPhaseBCount).toEqual(0);
+});

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -740,8 +740,12 @@ test('endPhaseOnMove', () => {
       },
     ],
   });
-  const state = { G: {}, ctx: flow.ctx(2) };
-  flow.processMove(state, { payload: {} });
+  let state = { G: {}, ctx: flow.ctx(2) };
+
+  expect(state.ctx.phase).toBe('A');
+  state = flow.processMove(state, { payload: {} });
+  expect(state.ctx.phase).toBe('B');
+
   expect(endPhaseACount).toEqual(1);
   expect(endPhaseBCount).toEqual(0);
 });


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).

#### Test

When a move is made it checks if the turn should end and if the phase should end.
In the situation of `phase A` ending the turn and the phase, it should start `phase B` end check `phase B` `endPhaseIf`.

Expected:
`phase A` - call onPhaseEnd 1 time
`phase b` - don't call onPhaseEnd