### PR TITLE
Allow enhancers for react-native clients

### DIFF
--- a/src/client/react-native.js
+++ b/src/client/react-native.js
@@ -27,7 +27,7 @@ import { Client as RawClient } from './client';
  *   API through props for it to interact with the framework
  *   and dispatch actions such as MAKE_MOVE.
  */
-export function Client({ game, numPlayers, board, multiplayer }) {
+export function Client({ game, numPlayers, board, multiplayer, enhancer }) {
   /*
    * WrappedBoard
    *
@@ -61,6 +61,7 @@ export function Client({ game, numPlayers, board, multiplayer }) {
         socketOpts: {
           transports: ['websocket'],
         },
+        enhancer,
       });
 
       this.client.subscribe(() => this.forceUpdate());

--- a/src/client/react-native.js
+++ b/src/client/react-native.js
@@ -21,6 +21,7 @@ import { Client as RawClient } from './client';
  * @param {...object} multiplayer - Set to true or { server: '<host>:<port>' }
  *                                  to make a multiplayer client. The second
  *                                  syntax specifies a non-default socket server.
+ * @param {...object} enhancer - Optional enhancer to send to the Redux store
  *
  * Returns:
  *   A React Native component that wraps board and provides an

--- a/src/client/react-native.test.js
+++ b/src/client/react-native.test.js
@@ -242,3 +242,15 @@ test('undo/redo', () => {
   board.props.redo();
   expect(board.props.G).toEqual({ arg: 42 });
 });
+
+test('can receive enhancer', () => {
+  const enhancer = jest.fn().mockImplementation(next => next);
+  const Board = Client({
+    game: Game({}),
+    board: TestBoard,
+    enhancer,
+  });
+
+  const game = Enzyme.mount(<Board />); // eslint-disable-line no-unused-vars
+  expect(enhancer).toBeCalled();
+});


### PR DESCRIPTION
The existing implementation doesn't support enhancers for react-native. This prevents redux debugging from working for RN clients.

Fixes #185

#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] Test coverage is 100% (or you have a story for why it's ok).
