### PR TITLE
Fix typo in docs about phase

### DIFF
--- a/docs/phases.md
+++ b/docs/phases.md
@@ -136,7 +136,7 @@ flow: {
   // Run at the end of a move.
   onMove: (G, ctx) => G
 
-  phase: [
+  phases: [
     {
       name: 'A',
 


### PR DESCRIPTION
Hi, I'm doing tutorials and perhaps found a typo in phase documentation (`flow.phase` => `flow.phases` ) . Thanks!

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
