### PR TITLE
Allow the lobby API to require a secret for all requests

### DIFF
--- a/src/server/api.js
+++ b/src/server/api.js
@@ -121,14 +121,16 @@ export const createApiServer = ({ db, games }) => {
 
   app.use(cors());
 
+  // If API_SECRET is set, then require that requests set an
+  // api-secret header that is set to the same value.
   app.use(async (ctx, next) => {
     await next();
 
     if (
-      !!process.env.LOBBY_SECRET &&
-      ctx.request.headers['lobby-secret'] !== process.env.LOBBY_SECRET
+      !!process.env.API_SECRET &&
+      ctx.request.headers['api-secret'] !== process.env.API_SECRET
     ) {
-      ctx.throw(403, 'Invalid lobby secret');
+      ctx.throw(403, 'Invalid API secret');
     }
   });
 

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -120,6 +120,18 @@ export const createApiServer = ({ db, games }) => {
   });
 
   app.use(cors());
+
+  app.use(async (ctx, next) => {
+    await next();
+
+    if (
+      !!process.env.LOBBY_SECRET &&
+      ctx.request.headers['lobby-secret'] !== process.env.LOBBY_SECRET
+    ) {
+      ctx.throw(403, 'Invalid lobby secret');
+    }
+  });
+
   app.use(router.routes()).use(router.allowedMethods());
 
   return app;

--- a/src/server/api.test.js
+++ b/src/server/api.test.js
@@ -173,7 +173,7 @@ describe('.createApiServer', () => {
 
     describe('for an unprotected lobby server', () => {
       beforeEach(async () => {
-        delete process.env.LOBBY_SECRET;
+        delete process.env.API_SECRET;
 
         app = createApiServer({ db, games });
 
@@ -233,7 +233,7 @@ describe('.createApiServer', () => {
 
     describe('for a protected lobby', () => {
       beforeEach(() => {
-        process.env.LOBBY_SECRET = 'protected';
+        process.env.API_SECRET = 'protected';
         app = createApiServer({ db, games });
       });
 
@@ -251,7 +251,7 @@ describe('.createApiServer', () => {
         beforeEach(async () => {
           response = await request(app.callback())
             .post('/games/foo/create')
-            .set('Lobby-Secret', 'protected');
+            .set('API-Secret', 'protected');
         });
 
         test('succeeds', () => {
@@ -274,7 +274,7 @@ describe('.createApiServer', () => {
 
     describe('for an unprotected lobby', () => {
       beforeEach(() => {
-        delete process.env.LOBBY_SECRET;
+        delete process.env.API_SECRET;
       });
 
       describe('when the game does not exist', () => {
@@ -345,7 +345,7 @@ describe('.createApiServer', () => {
 
     describe('for an protected lobby', () => {
       beforeEach(() => {
-        process.env.LOBBY_SECRET = 'protected';
+        process.env.API_SECRET = 'protected';
       });
 
       describe('without the lobby token', () => {
@@ -381,7 +381,7 @@ describe('.createApiServer', () => {
 
           response = await request(app.callback())
             .patch('/game_instances/1/join')
-            .set('Lobby-Secret', 'protected')
+            .set('API-Secret', 'protected')
             .send('gameName=foo&playerID=0&playerName=alice');
         });
 


### PR DESCRIPTION
If an environment variable `LOBBY_SECRET` is provided when the API server is started, then all API requests will require that secret in a header named `lobby-secret`. (Issue #198)

This check is provided as a middleware for the API koa server.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).