### PR TITLE
Use parse/stringify from flatted lib to support circular structures (fixes #222)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6087,6 +6087,11 @@
         "write": "0.2.1"
       }
     },
+    "flatted": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-0.2.3.tgz",
+      "integrity": "sha512-C4B5UtK3kOrLAyZ1ftqEWprxCfLmCIqEcNufZrtsJhiZ/fcI5mvCgtAtC3pu7BC9KE7aUIrPXwTgcT1fiI7QhA=="
+    },
     "flatten": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
   "dependencies": {
     "@koa/cors": "^2.2.1",
     "firebase": "^5.0.4",
+    "flatted": "^0.2.3",
     "koa": "^2.3.0",
     "koa-body": "^2.5.0",
     "koa-router": "^7.2.1",

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -16,6 +16,7 @@ import { PlayerInfo } from './playerinfo';
 import { DebugMove } from './debug-move';
 import { GameLog } from '../log/log';
 import { restore } from '../../core/action-creators';
+import { parse, stringify } from 'flatted/cjs';
 import './debug.css';
 
 /**
@@ -102,14 +103,14 @@ export class Debug extends React.Component {
   }
 
   saveState = () => {
-    const json = JSON.stringify(this.props.gamestate);
+    const json = stringify(this.props.gamestate);
     window.localStorage.setItem('gamestate', json);
   };
 
   restoreState = () => {
     const gamestateJSON = window.localStorage.getItem('gamestate');
     if (gamestateJSON !== null) {
-      const gamestate = JSON.parse(gamestateJSON);
+      const gamestate = parse(gamestateJSON);
       this.props.store.dispatch(restore(gamestate));
     }
   };
@@ -237,14 +238,14 @@ export class Debug extends React.Component {
               <section>
                 <pre className="json">
                   <strong>ctx</strong>:{' '}
-                  {JSON.stringify(this.props.gamestate.ctx, null, 2)}
+                  {stringify(this.props.gamestate.ctx, null, 2)}
                 </pre>
               </section>
 
               <section>
                 <pre className="json">
                   <strong>G</strong>:{' '}
-                  {JSON.stringify(this.props.gamestate.G, null, 2)}
+                  {stringify(this.props.gamestate.G, null, 2)}
                 </pre>
               </section>
             </span>

--- a/src/client/debug/debug.test.js
+++ b/src/client/debug/debug.test.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { stringify } from 'flatted/cjs';
 import { restore, makeMove, gameEvent } from '../../core/action-creators';
 import Game from '../../core/game';
 import { CreateGameReducer } from '../../core/reducer';
@@ -84,7 +85,7 @@ describe('save / restore', () => {
   });
 
   const restoredState = { restore: true };
-  let restoredJSON = JSON.stringify(restoredState);
+  let restoredJSON = stringify(restoredState);
   const setItem = jest.fn();
   const getItem = jest.fn(() => restoredJSON);
 

--- a/src/client/debug/gameinfo.js
+++ b/src/client/debug/gameinfo.js
@@ -8,11 +8,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { stringify } from 'flatted/cjs';
 
 const Item = props => (
   <div className="gameinfo-item">
     <strong>{props.name} </strong>
-    <div>{JSON.stringify(props.value)}</div>
+    <div>{stringify(props.value)}</div>
   </div>
 );
 

--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -6,6 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import { parse, stringify } from 'flatted/cjs';
 import * as Actions from './action-types';
 import { Random } from './random';
 import { Events } from './events';
@@ -72,7 +73,7 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
   initial.ctx = Random.detach(initial.ctx);
   initial.ctx = Events.detach(initial.ctx);
 
-  const deepCopy = obj => JSON.parse(JSON.stringify(obj));
+  const deepCopy = obj => parse(stringify(obj));
   initial._initial = deepCopy(initial);
 
   /**


### PR DESCRIPTION
This PR fixes the problem described in #222. It replaces the use of JSON.stringify/JSON.parse with functions from the flatted library.

Instead of just fixing that problem, this PR changes stringify/parse to flatted in all parts that consitute the library itself - i.e. the examples and the storybook are unchanged.


#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).