### PR TITLE
Log visualize phases

### DIFF
--- a/src/client/log/log.css
+++ b/src/client/log/log.css
@@ -14,6 +14,8 @@
   background: #fff;
   border: 1px dotted #ccc;
   border-left: 5px solid #ccc;
+  border-top: 2px solid #ccc;
+  border-bottom: 2px solid #ccc;
   margin-bottom: 5px;
   padding: 5px;
   text-align: center;
@@ -47,6 +49,39 @@
   text-align: center;
   font-weight: bold;
   margin-bottom: 10px;
+}
+
+.gamelog div.phase0 {
+  border-top-color: red;
+  border-bottom-color: red;
+}
+.gamelog div.phase0to1 {
+  border-top-color: red;
+  border-bottom-color: blue;
+}
+.gamelog div.phase1 {
+  border-top-color: blue;
+  border-bottom-color: blue;
+}
+.gamelog div.phase1to2 {
+  border-top-color: blue;
+  border-bottom-color: green;
+}
+.gamelog div.phase2 {
+  border-top-color: green;
+  border-bottom-color: green;
+}
+.gamelog div.phase2to3 {
+  border-top-color: green;
+  border-bottom-color: yellow;
+}
+.gamelog div.phase3 {
+  border-top-color: yellow;
+  border-bottom-color: yellow;
+}
+.gamelog div.phase3to0 {
+  border-top-color: yellow;
+  border-bottom-color: red;
 }
 
 .gamelog .turn-marker:not(:first-child) {

--- a/src/client/log/log.js
+++ b/src/client/log/log.js
@@ -24,9 +24,11 @@ const LogEvent = props => {
   if (playerID !== undefined) {
     classNames += ` player${playerID}`;
   }
-
   if (props.pinned) {
     classNames += ' pinned';
+  }
+  if (props.phase !== undefined) {
+    classNames += ` phase${props.phase}`;
   }
 
   return (
@@ -48,6 +50,7 @@ LogEvent.propTypes = {
   onMouseEnter: PropTypes.func.isRequired,
   onMouseLeave: PropTypes.func.isRequired,
   pinned: PropTypes.bool,
+  phase: PropTypes.string,
 };
 
 const TurnMarker = props => (
@@ -123,6 +126,8 @@ export class GameLog extends React.Component {
     let turn = 1;
     let turnDelimiter = true;
 
+    let currentPhase = 0;
+
     for (let i = 0; i < this.props.log.length; i++) {
       if (turnDelimiter) {
         turnDelimiter = false;
@@ -130,6 +135,14 @@ export class GameLog extends React.Component {
       }
 
       const action = this.props.log[i];
+
+      let phase = currentPhase;
+      if (action.payload.type == 'endPhase') {
+        const oldPhase = currentPhase;
+        currentPhase = (currentPhase + 1) % 4;
+        phase = `${oldPhase}to${currentPhase}`;
+      }
+
       log.push(
         <LogEvent
           key={i}
@@ -139,6 +152,7 @@ export class GameLog extends React.Component {
           onMouseEnter={this.onMouseEnter}
           onMouseLeave={this.onMouseLeave}
           action={action}
+          phase={phase}
         />
       );
 

--- a/src/client/log/log.js
+++ b/src/client/log/log.js
@@ -19,7 +19,11 @@ const LogEvent = props => {
   const action = props.action;
   const args = action.payload.args || [];
   const playerID = action.payload.playerID;
-  let classNames = `log-event player${playerID}`;
+
+  let classNames = `log-event`;
+  if (playerID !== undefined) {
+    classNames += ` player${playerID}`;
+  }
 
   if (props.pinned) {
     classNames += ' pinned';


### PR DESCRIPTION
This PR implements a part of  #227 - namely, visualize phases and changes thereof.
I'm no designer, but with this, the current phase and changes thereof are clearly visible.

![image](https://user-images.githubusercontent.com/1977938/43220189-bcfdcb1a-9049-11e8-8baf-79b552a8c762.png)

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).

#### Note

Nicolo will be away for 2-3 weeks starting July 16th 2018, so expect some delays in getting a response.
