### PR TITLE
allow multiplayer client creation to be overridden

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -91,8 +91,14 @@ class _ClientImpl {
     this.credentials = credentials;
 
     let server = undefined;
-    if (multiplayer instanceof Object && 'server' in multiplayer) {
-      server = multiplayer.server;
+    let MultiplayerClientImpl = Multiplayer;
+    if (multiplayer instanceof Object) {
+      if ('server' in multiplayer) {
+        server = multiplayer.server;
+      }
+      if ('clientImpl' in multiplayer) {
+        MultiplayerClientImpl = multiplayer.clientImpl;
+      }
       multiplayer = true;
     }
 
@@ -134,7 +140,7 @@ class _ClientImpl {
     this.store = null;
 
     if (multiplayer) {
-      this.multiplayerClient = new Multiplayer({
+      this.multiplayerClient = new MultiplayerClientImpl({
         gameID: gameID,
         playerID: playerID,
         gameName: game.name,
@@ -264,7 +270,7 @@ class _ClientImpl {
  *
  * @param {...object} game - The return value of `Game`.
  * @param {...object} numPlayers - The number of players.
- * @param {...object} multiplayer - Set to true or { server: '<host>:<port>' }
+ * @param {...object} multiplayer - Set to true or { server: '<host>:<port>', clientImpl?: Multiplayer client class }
  *                                  to make a multiplayer client. The second
  *                                  syntax specifies a non-default socket server.
  * @param {...object} socketOpts - Options to pass to socket.io.


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).

(I'm starting to experiment with an alternative multiplayer client, would be great if I could keep connection with source repo instead of forking it)

1- This allows inheritance by exposing Client class directly instead of wrapping a _ClientImpl.
2- 'new Multiplayer' is replace by a call to overridable function 'createMultiplayerClient'