### PR TITLE
Compactify transferdata (deltalog, _initial)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,7 @@ get done before we are ready for a v1 release.
 ### Lobby
 
 * [x] basic `create` and `join` API
-* [ ] simple web-based lobby ([issue](https://github.com/google/boardgame.io/issues/197))  **[help needed]**
+* [ ] simple web-based lobby ([issue](https://github.com/google/boardgame.io/issues/197)) **[help needed]**
 
 ### Storage
 

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -15,7 +15,7 @@ import { Controls } from './controls';
 import { PlayerInfo } from './playerinfo';
 import { DebugMove } from './debug-move';
 import { GameLog } from '../log/log';
-import { restore } from '../../core/action-creators';
+import { sync } from '../../core/action-creators';
 import { parse, stringify } from 'flatted';
 import './debug.css';
 
@@ -124,7 +124,7 @@ export class Debug extends React.Component {
     const gamestateJSON = window.localStorage.getItem('gamestate');
     if (gamestateJSON !== null) {
       const gamestate = parse(gamestateJSON);
-      this.props.store.dispatch(restore(gamestate));
+      this.props.store.dispatch(sync(gamestate));
     }
   };
 

--- a/src/client/debug/debug.test.js
+++ b/src/client/debug/debug.test.js
@@ -8,9 +8,9 @@
 
 import React from 'react';
 import { stringify } from 'flatted';
-import { restore, makeMove, gameEvent } from '../../core/action-creators';
+import { Client } from '../client';
+import { sync } from '../../core/action-creators';
 import Game from '../../core/game';
-import { CreateGameReducer } from '../../core/reducer';
 import { createStore } from 'redux';
 import { Debug } from './debug';
 import Mousetrap from 'mousetrap';
@@ -110,7 +110,7 @@ describe('save / restore', () => {
   test('restore', () => {
     Mousetrap.simulate('3');
     expect(getItem).toHaveBeenCalled();
-    expect(loggedAction).toEqual(restore(restoredState));
+    expect(loggedAction).toEqual(sync(restoredState));
   });
 
   test('restore from nothing does nothing', () => {
@@ -151,18 +151,16 @@ describe('log', () => {
         A: (G, ctx, arg) => ({ arg }),
       },
     });
-    const reducer = CreateGameReducer({ game });
-    let state = reducer(undefined, { type: 'init' });
-    state = reducer(state, makeMove('A', [42]));
-    let log = [...(state.deltalog || [])];
-    state = reducer(state, gameEvent('endTurn'));
-    log = [...log, ...(state.deltalog || [])];
+
+    const client = Client({ game });
+    client.moves.A(42);
+    client.events.endTurn();
 
     const debug = Enzyme.mount(
       <Debug
         overrideGameState={overrideGameState}
-        reducer={reducer}
-        gamestate={{ ...state, log }}
+        reducer={client.reducer}
+        gamestate={client.getState()}
         endTurn={() => {}}
         gameID="default"
       />

--- a/src/client/debug/debug.test.js
+++ b/src/client/debug/debug.test.js
@@ -154,13 +154,15 @@ describe('log', () => {
     const reducer = CreateGameReducer({ game });
     let state = reducer(undefined, { type: 'init' });
     state = reducer(state, makeMove('A', [42]));
+    let log = [...(state.deltalog || [])];
     state = reducer(state, gameEvent('endTurn'));
+    log = [...log, ...(state.deltalog || [])];
 
     const debug = Enzyme.mount(
       <Debug
         overrideGameState={overrideGameState}
         reducer={reducer}
-        gamestate={state}
+        gamestate={{ ...state, log }}
         endTurn={() => {}}
         gameID="default"
       />

--- a/src/client/log/log.test.js
+++ b/src/client/log/log.test.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { Client } from '../client';
 import { makeMove, gameEvent } from '../../core/action-creators';
 import Game from '../../core/game';
 import { GameLog } from './log';
@@ -73,41 +74,31 @@ describe('time travel', () => {
     },
   });
 
-  let log = [];
-  const reducer = CreateGameReducer({ game });
-  let state = reducer(undefined, { type: 'init' });
-  const initialState = state;
-  log = [...log, ...(state.deltalog || [])];
+  const client = Client({ game });
+  const initialState = client.getState()._initial;
 
-  state = reducer(state, makeMove('A', [1]));
-  log = [...log, ...(state.deltalog || [])];
-
-  state = reducer(state, gameEvent('endTurn'));
-  log = [...log, ...(state.deltalog || [])];
-
-  // Also ends turn automatically.
-  state = reducer(state, makeMove('A', [42]));
-  log = [...log, ...(state.deltalog || [])];
-  state = reducer(state, makeMove('A', [2]));
-  log = [...log, ...(state.deltalog || [])];
-  state = reducer(state, gameEvent('endTurn'));
-  log = [...log, ...(state.deltalog || [])];
+  client.moves.A(1);
+  client.events.endTurn();
+  // Also ends the turn automatically.
+  client.moves.A(42);
+  client.moves.A(2);
+  client.events.endTurn();
 
   let hoverState = null;
 
   const root = Enzyme.mount(
     <GameLog
-      log={log}
+      log={client.log}
       initialState={initialState}
       onHover={({ state }) => {
         hoverState = state;
       }}
-      reducer={reducer}
+      reducer={client.reducer}
     />
   );
 
   test('before rewind', () => {
-    expect(state.G).toMatchObject({ arg: 2 });
+    expect(client.getState().G).toMatchObject({ arg: 2 });
   });
 
   test('regular move', () => {

--- a/src/client/log/log.test.js
+++ b/src/client/log/log.test.js
@@ -73,22 +73,31 @@ describe('time travel', () => {
     },
   });
 
+  let log = [];
   const reducer = CreateGameReducer({ game });
   let state = reducer(undefined, { type: 'init' });
   const initialState = state;
+  log = [...log, ...(state.deltalog || [])];
 
   state = reducer(state, makeMove('A', [1]));
+  log = [...log, ...(state.deltalog || [])];
+
   state = reducer(state, gameEvent('endTurn'));
+  log = [...log, ...(state.deltalog || [])];
+
   // Also ends turn automatically.
   state = reducer(state, makeMove('A', [42]));
+  log = [...log, ...(state.deltalog || [])];
   state = reducer(state, makeMove('A', [2]));
+  log = [...log, ...(state.deltalog || [])];
   state = reducer(state, gameEvent('endTurn'));
+  log = [...log, ...(state.deltalog || [])];
 
   let hoverState = null;
 
   const root = Enzyme.mount(
     <GameLog
-      log={state.log}
+      log={log}
       initialState={initialState}
       onHover={({ state }) => {
         hoverState = state;

--- a/src/client/multiplayer/multiplayer.js
+++ b/src/client/multiplayer/multiplayer.js
@@ -103,10 +103,11 @@ export class Multiplayer {
     }
 
     this.socket.on('sync', (gameID, state) => {
-      if (
-        gameID == this.gameID &&
-        state._stateID >= this.store.getState()._stateID
-      ) {
+      const currentState = this.store.getState();
+      if (gameID == this.gameID && state._stateID >= currentState._stateID) {
+        // restore _initial that was stripped server-side
+        state._initial = currentState._initial;
+
         const action = ActionCreators.restore(state);
         action._remote = true;
         this.store.dispatch(action);

--- a/src/client/multiplayer/multiplayer.js
+++ b/src/client/multiplayer/multiplayer.js
@@ -104,9 +104,16 @@ export class Multiplayer {
 
     this.socket.on('sync', (gameID, state) => {
       const currentState = this.store.getState();
+
       if (gameID == this.gameID && state._stateID >= currentState._stateID) {
-        // restore _initial that was stripped server-side
-        state._initial = currentState._initial;
+        state = Object.assign({}, state, {
+          // re-apply the deltalog
+          log: [...currentState.log, ...(state.deltalog || [])],
+          // drop deltalog
+          deltalog: undefined,
+          // restore _initial that was stripped server-side
+          _initial: currentState._initial,
+        });
 
         const action = ActionCreators.restore(state);
         action._remote = true;

--- a/src/client/multiplayer/multiplayer.test.js
+++ b/src/client/multiplayer/multiplayer.test.js
@@ -34,15 +34,25 @@ test('Multiplayer defaults', () => {
   m.callback();
 });
 
-test('update gameID / playerID', () => {
-  const m = new Multiplayer();
+describe('update gameID / playerID', () => {
+  const socket = new MockSocket();
+  const m = new Multiplayer({ socket });
   const game = Game({});
   m.createStore(CreateGameReducer({ game }));
 
-  m.updateGameID('test');
-  m.updatePlayerID('player');
-  expect(m.gameID).toBe('default:test');
-  expect(m.playerID).toBe('player');
+  beforeEach(() => (socket.emit = jest.fn()));
+
+  test('gameID', () => {
+    m.updateGameID('test');
+    expect(m.gameID).toBe('default:test');
+    expect(socket.emit).lastCalledWith('sync', 'default:test', null, 2);
+  });
+
+  test('playerID', () => {
+    m.updatePlayerID('player');
+    expect(m.playerID).toBe('player');
+    expect(socket.emit).lastCalledWith('sync', 'default:test', 'player', 2);
+  });
 });
 
 test('connection status', () => {
@@ -68,48 +78,59 @@ test('connection status', () => {
   expect(m.isConnected).toBe(false);
 });
 
-test('multiplayer', () => {
+describe('multiplayer', () => {
   const mockSocket = new MockSocket();
   const m = new Multiplayer({ socket: mockSocket });
   m.connect();
   const game = Game({});
-  const store = m.createStore(CreateGameReducer({ game }));
+  let store = null;
 
-  // Returns a valid store.
-  expect(store).not.toBe(undefined);
+  beforeEach(() => {
+    store = m.createStore(CreateGameReducer({ game }));
+  });
 
-  const action = ActionCreators.gameEvent('endTurn');
+  test('returns a valid store', () => {
+    expect(store).not.toBe(undefined);
+  });
 
-  // Dispatch a local action.
-  mockSocket.emit = jest.fn();
-  store.dispatch(action);
-  expect(mockSocket.emit).lastCalledWith(
-    'action',
-    action,
-    0,
-    'default:default',
-    null
-  );
+  test('client sends update after action', () => {
+    const action = ActionCreators.gameEvent('endTurn');
+    mockSocket.emit = jest.fn();
+    store.dispatch(action);
+    expect(mockSocket.emit).lastCalledWith(
+      'update',
+      action,
+      0,
+      'default:default',
+      null
+    );
+  });
 
-  // sync restores state.
-  const restored = { restore: true };
-  expect(store.getState()).not.toMatchObject(restored);
-  mockSocket.receive('sync', 'unknown gameID', restored);
-  expect(store.getState()).not.toMatchObject(restored);
-  mockSocket.receive('sync', 'default:default', restored);
-  expect(store.getState()).not.toMatchObject(restored);
-  // Only if the stateID is not stale.
-  restored._stateID = 1;
-  mockSocket.receive('sync', 'default:default', restored);
-  expect(store.getState()).toMatchObject(restored);
+  test('receive update', () => {
+    const restored = { restore: true };
+    expect(store.getState()).not.toMatchObject(restored);
+    mockSocket.receive('update', 'unknown gameID', restored);
+    expect(store.getState()).not.toMatchObject(restored);
+    mockSocket.receive('update', 'default:default', restored);
+    expect(store.getState()).not.toMatchObject(restored);
 
-  // updateGameID causes a sync.
-  mockSocket.emit = jest.fn();
-  m.updateGameID('id');
-  expect(mockSocket.emit).lastCalledWith('sync', 'default:id', null, 2);
+    // Only if the stateID is not stale.
+    restored._stateID = 1;
+    mockSocket.receive('update', 'default:default', restored);
+    expect(store.getState()).toMatchObject(restored);
+  });
+
+  test('receive sync', () => {
+    const restored = { restore: true };
+    expect(store.getState()).not.toMatchObject(restored);
+    mockSocket.receive('sync', 'unknown gameID', restored);
+    expect(store.getState()).not.toMatchObject(restored);
+    mockSocket.receive('sync', 'default:default', restored);
+    expect(store.getState()).toMatchObject(restored);
+  });
 });
 
-test('move blacklist', () => {
+describe('move blacklist', () => {
   const mockSocket = new MockSocket();
   const m = new Multiplayer({ socket: mockSocket });
   const game = Game({});
@@ -117,19 +138,28 @@ test('move blacklist', () => {
 
   mockSocket.emit = jest.fn();
 
-  const endTurn = ActionCreators.gameEvent('endTurn');
+  beforeEach(() => mockSocket.emit.mockReset());
 
-  store.dispatch(endTurn);
-  expect(mockSocket.emit).toHaveBeenCalled();
-  mockSocket.emit.mockReset();
+  test('should emit', () => {
+    const endTurn = ActionCreators.gameEvent('endTurn');
+    store.dispatch(endTurn);
+    expect(mockSocket.emit).toHaveBeenCalled();
+  });
 
-  store.dispatch(ActionCreators.makeMove());
-  expect(mockSocket.emit).toHaveBeenCalled();
-  mockSocket.emit.mockReset();
+  test('should emit', () => {
+    store.dispatch(ActionCreators.makeMove());
+    expect(mockSocket.emit).toHaveBeenCalled();
+  });
 
-  store.dispatch(ActionCreators.restore());
-  expect(mockSocket.emit).not.toHaveBeenCalled();
-  mockSocket.emit.mockReset();
+  test('should not emit', () => {
+    store.dispatch(ActionCreators.sync());
+    expect(mockSocket.emit).not.toHaveBeenCalled();
+  });
+
+  test('should not emit', () => {
+    store.dispatch(ActionCreators.update());
+    expect(mockSocket.emit).not.toHaveBeenCalled();
+  });
 });
 
 describe('server option', () => {
@@ -207,7 +237,7 @@ test('changing a gameID resets the state before resync', () => {
   expect(dispatchSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       type: Actions.RESET,
-      _remote: true,
+      clientOnly: true,
     })
   );
 });
@@ -223,44 +253,7 @@ test('changing a playerID resets the state before resync', () => {
   expect(dispatchSpy).toHaveBeenCalledWith(
     expect.objectContaining({
       type: Actions.RESET,
-      _remote: true,
+      clientOnly: true,
     })
   );
-});
-
-test('deltalog', () => {
-  const mockSocket = new MockSocket();
-  const m = new Multiplayer({ socket: mockSocket });
-  m.connect();
-  const game = Game({});
-  const store = m.createStore(CreateGameReducer({ game }));
-
-  // receive a sync message with one deltalog entry
-  mockSocket.receive('sync', 'default:default', {
-    _stateID: 1,
-    deltalog: [{ msg: 'dl1' }],
-  });
-  let statelog = store.getState().log;
-  expect(statelog).toMatchObject([{ msg: 'dl1' }]);
-
-  // receive another sync message with one deltalog entry
-  mockSocket.receive('sync', 'default:default', {
-    _stateID: 2,
-    deltalog: [{ msg: 'dl2' }],
-  });
-  statelog = store.getState().log;
-  expect(statelog).toMatchObject([{ msg: 'dl1' }, { msg: 'dl2' }]);
-
-  // more than one entry in deltalog
-  mockSocket.receive('sync', 'default:default', {
-    _stateID: 3,
-    deltalog: [{ msg: 'dl3' }, { msg: 'dl4' }],
-  });
-  statelog = store.getState().log;
-  expect(statelog).toMatchObject([
-    { msg: 'dl1' },
-    { msg: 'dl2' },
-    { msg: 'dl3' },
-    { msg: 'dl4' },
-  ]);
 });

--- a/src/core/action-creators.js
+++ b/src/core/action-creators.js
@@ -48,12 +48,28 @@ export const automaticGameEvent = (type, args, playerID, credentials) => ({
 });
 
 /**
- * Used to reset the Redux store's state.
+ * Used to reset the Redux store's state on a sync.
  * @param {object} state - The state to restore.
+ * @param {Array} log - The log to restore.
  */
-export const restore = state => ({
-  type: Actions.RESTORE,
+export const sync = (state, log) => ({
+  type: Actions.SYNC,
   state,
+  log,
+  clientOnly: true,
+});
+
+/**
+ * Used to update the Redux store's state in response to
+ * an action coming from another player.
+ * @param {object} state - The state to restore.
+ * @param {Array} deltalog - A log delta.
+ */
+export const update = (state, deltalog) => ({
+  type: Actions.UPDATE,
+  state,
+  deltalog,
+  clientOnly: true,
 });
 
 /**
@@ -61,6 +77,7 @@ export const restore = state => ({
  */
 export const reset = () => ({
   type: Actions.RESET,
+  clientOnly: true,
 });
 
 /**

--- a/src/core/action-types.js
+++ b/src/core/action-types.js
@@ -8,7 +8,8 @@
 
 export const MAKE_MOVE = 'MAKE_MOVE';
 export const GAME_EVENT = 'GAME_EVENT';
-export const RESTORE = 'RESTORE';
-export const RESET = 'RESET';
-export const UNDO = 'UNDO';
 export const REDO = 'REDO';
+export const RESET = 'RESET';
+export const SYNC = 'SYNC';
+export const UNDO = 'UNDO';
+export const UPDATE = 'UPDATE';

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -41,9 +41,12 @@ export class Events {
   update(state) {
     for (const item of this.dispatch) {
       const action = automaticGameEvent(item.key, item.args, this.playerID);
+      const adsf = this.flow.processGameEvent(state, action);
+      const deltalog = [...(state.deltalog || []), ...(adsf.deltalog || [])];
       state = {
         ...state,
-        ...this.flow.processGameEvent(state, action),
+        ...adsf,
+        deltalog,
       };
     }
     return state;

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -41,11 +41,11 @@ export class Events {
   update(state) {
     for (const item of this.dispatch) {
       const action = automaticGameEvent(item.key, item.args, this.playerID);
-      const adsf = this.flow.processGameEvent(state, action);
-      const deltalog = [...(state.deltalog || []), ...(adsf.deltalog || [])];
+      const newState = this.flow.processGameEvent(state, action);
+      const deltalog = [...(state.deltalog || []), ...newState.deltalog];
       state = {
         ...state,
-        ...adsf,
+        ...newState,
         deltalog,
       };
     }

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -41,12 +41,9 @@ export class Events {
   update(state) {
     for (const item of this.dispatch) {
       const action = automaticGameEvent(item.key, item.args, this.playerID);
-      const newState = this.flow.processGameEvent(state, action);
-      const deltalog = [...(state.deltalog || []), ...newState.deltalog];
       state = {
         ...state,
-        ...newState,
-        deltalog,
+        ...this.flow.processGameEvent(state, action),
       };
     }
     return state;

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -75,10 +75,9 @@ export function Flow({
     if (events.hasOwnProperty(payload.type)) {
       const context = { playerID: payload.playerID, dispatch };
       const args = [state].concat(payload.args);
-      const oldLog = state.log || [];
-      const log = [...oldLog, action];
+      const deltalog = [action];
       const newState = events[payload.type].apply(context, args);
-      return { ...newState, log };
+      return { ...newState, deltalog };
     }
     return state;
   };

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -74,10 +74,10 @@ export function Flow({
     const { payload } = action;
     if (events.hasOwnProperty(payload.type)) {
       const context = { playerID: payload.playerID, dispatch };
+      const deltalog = [...(state.deltalog || []), action];
+      state = { ...state, deltalog };
       const args = [state].concat(payload.args);
-      const deltalog = [action];
-      const newState = events[payload.type].apply(context, args);
-      return { ...newState, deltalog };
+      return events[payload.type].apply(context, args);
     }
     return state;
   };

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -341,7 +341,9 @@ test('endGameIf', () => {
     expect(state.ctx.currentPlayer).toBe('0');
     state = reducer(state, makeMove('A'));
     expect(state.ctx.gameover).toBe('A');
-    expect(state.deltalog[1].payload.type).toBe('endTurn');
+    expect(state.deltalog[state.deltalog.length - 1].payload.type).toBe(
+      'endTurn'
+    );
   }
 });
 

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -341,7 +341,7 @@ test('endGameIf', () => {
     expect(state.ctx.currentPlayer).toBe('0');
     state = reducer(state, makeMove('A'));
     expect(state.ctx.gameover).toBe('A');
-    expect(state.log[state.log.length - 1].payload.type).toBe('endTurn');
+    expect(state.deltalog[1].payload.type).toBe('endTurn');
   }
 });
 

--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -118,6 +118,9 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
         // Attach Events API to ctx.
         state = { ...state, ctx: events.attach(state.ctx) };
 
+        // delete deltalog from previous move/event
+        state = { ...state, deltalog: undefined };
+
         // Update state.
         let newState = game.flow.processGameEvent(state, action);
         // Trigger any events that were called via the Events API.
@@ -187,8 +190,13 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
           G = state.G;
         }
 
-        const log = [...state.log, action];
-        state = { ...state, G, ctx, log, _stateID: state._stateID + 1 };
+        state = {
+          ...state,
+          deltalog: undefined,
+          G,
+          ctx,
+          _stateID: state._stateID + 1,
+        };
 
         // If we're on the client, just process the move
         // and no triggers in multiplayer mode.
@@ -203,6 +211,7 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
         state = { ...state, ctx: events.attach(state.ctx) };
         state = game.flow.processMove(state, action.payload);
         state = events.update(state);
+        state.deltalog = [action, ...(state.deltalog || [])];
         state = { ...state, ctx: random.update(state.ctx) };
         state = { ...state, ctx: Random.detach(state.ctx) };
         state = { ...state, ctx: Events.detach(state.ctx) };

--- a/src/core/reducer.test.js
+++ b/src/core/reducer.test.js
@@ -11,7 +11,8 @@ import { CreateGameReducer } from './reducer';
 import {
   makeMove,
   gameEvent,
-  restore,
+  sync,
+  update,
   reset,
   undo,
   redo,
@@ -96,9 +97,15 @@ test('disable move by invalid playerIDs', () => {
   expect(state._stateID).toBe(2);
 });
 
-test('restore', () => {
+test('sync', () => {
   const reducer = CreateGameReducer({ game });
-  const state = reducer(undefined, restore({ G: 'restored' }));
+  const state = reducer(undefined, sync({ G: 'restored' }));
+  expect(state).toEqual({ G: 'restored' });
+});
+
+test('update', () => {
+  const reducer = CreateGameReducer({ game });
+  const state = reducer(undefined, update({ G: 'restored' }));
   expect(state).toEqual({ G: 'restored' });
 });
 
@@ -192,7 +199,7 @@ test('numPlayers', () => {
   expect(state.ctx.numPlayers).toBe(4);
 });
 
-test('log', () => {
+test('deltalog', () => {
   const reducer = CreateGameReducer({ game });
 
   let state = undefined;

--- a/src/core/reducer.test.js
+++ b/src/core/reducer.test.js
@@ -202,11 +202,11 @@ test('log', () => {
   const actionC = gameEvent('endTurn');
 
   state = reducer(state, actionA);
-  expect(state.log).toEqual([actionA]);
+  expect(state.deltalog).toEqual([actionA]);
   state = reducer(state, actionB);
-  expect(state.log).toEqual([actionA, actionB]);
+  expect(state.deltalog).toEqual([actionB]);
   state = reducer(state, actionC);
-  expect(state.log).toEqual([actionA, actionB, actionC]);
+  expect(state.deltalog).toEqual([actionC]);
 });
 
 describe('Random inside setup()', () => {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -94,6 +94,8 @@ export function Server({ games, db, _clientInfo, _roomInfo }) {
             const newState = Object.assign({}, state, {
               G: game.playerView(state.G, ctx, playerID),
               ctx: ctx,
+              // _initial is sent during "sync" already, no need to send it again
+              _initial: undefined,
             });
 
             if (client === socket.id) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -111,7 +111,7 @@ export function Server({ games, db, _clientInfo, _roomInfo }) {
           }
 
           // reconstruct the whole log from deltalogs
-          const log = [...(state.deltalog || []), ...(newState.deltalog || [])];
+          const log = [...(state.deltalog || []), ...newState.deltalog];
           const storeState = { ...newState, log };
 
           await db.set(gameID, storeState);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -92,13 +92,13 @@ export function Server({ games, db, _clientInfo, _roomInfo }) {
           const roomClients = roomInfo.get(gameID);
           for (const client of roomClients.values()) {
             const { playerID } = clientInfo.get(client);
-            const ctx = Object.assign({}, state.ctx, { _random: undefined });
-            const filteredState = Object.assign({}, state, {
-              G: game.playerView(state.G, ctx, playerID),
-              ctx: ctx,
+            const filteredState = {
+              ...state,
+              G: game.playerView(state.G, state.ctx, playerID),
+              ctx: { ...state.ctx, _random: undefined },
               log: undefined,
               deltalog: undefined,
-            });
+            };
 
             if (client === socket.id) {
               socket.emit('update', gameID, filteredState, state.deltalog);
@@ -113,7 +113,7 @@ export function Server({ games, db, _clientInfo, _roomInfo }) {
           // object before storing it, but this should probably
           // sit in a different part of the database eventually.
           log = [...log, ...state.deltalog];
-          const stateWithLog = Object.assign({}, state, log);
+          const stateWithLog = { ...state, log };
 
           await db.set(gameID, stateWithLog);
         }
@@ -142,13 +142,13 @@ export function Server({ games, db, _clientInfo, _roomInfo }) {
           await db.set(gameID, state);
         }
 
-        const ctx = Object.assign({}, state.ctx, { _random: undefined });
-        const filteredState = Object.assign({}, state, {
-          G: game.playerView(state.G, ctx, playerID),
-          ctx: ctx,
+        const filteredState = {
+          ...state,
+          G: game.playerView(state.G, state.ctx, playerID),
+          ctx: { ...state.ctx, _random: undefined },
           log: undefined,
           deltalog: undefined,
-        });
+        };
 
         socket.emit('sync', gameID, filteredState, state.log);
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -82,7 +82,7 @@ export function Server({ games, db, _clientInfo, _roomInfo }) {
         }
 
         if (state._stateID == stateID) {
-          let log = store.getState().log;
+          let log = store.getState().log || [];
 
           // Update server's version of the store.
           store.dispatch(action);
@@ -138,7 +138,6 @@ export function Server({ games, db, _clientInfo, _roomInfo }) {
         if (state === undefined) {
           const store = Redux.createStore(reducer);
           state = store.getState();
-          state.log = [];
           await db.set(gameID, state);
         }
 

--- a/src/server/index.test.js
+++ b/src/server/index.test.js
@@ -173,52 +173,6 @@ test('action', async () => {
   await io.socket.receive('action', action, 0, 'gameID', '0');
   expect(io.socket.emit).lastCalledWith('sync', 'gameID', {
     G: {},
-    _initial: {
-      G: {},
-      _initial: {},
-      _redo: [],
-      _stateID: 0,
-      _undo: [
-        {
-          G: {},
-          ctx: {
-            _random: { seed: 0 },
-            actionPlayers: ['0'],
-            allPlayed: false,
-            allowedMoves: null,
-            currentPlayer: '0',
-            currentPlayerMoves: 0,
-            numPlayers: 2,
-            phase: 'default',
-            playOrder: ['0', '1'],
-            playOrderPos: 0,
-            stats: {
-              phase: { allPlayed: false, numMoves: {} },
-              turn: { numMoves: {} },
-            },
-            turn: 0,
-          },
-        },
-      ],
-      ctx: {
-        _random: { seed: 0 },
-        actionPlayers: ['0'],
-        allPlayed: false,
-        allowedMoves: null,
-        currentPlayer: '0',
-        currentPlayerMoves: 0,
-        numPlayers: 2,
-        phase: 'default',
-        playOrder: ['0', '1'],
-        playOrderPos: 0,
-        stats: {
-          phase: { allPlayed: false, numMoves: {} },
-          turn: { allPlayed: false, numMoves: {} },
-        },
-        turn: 0,
-      },
-      log: [],
-    },
     _redo: [],
     _stateID: 1,
     _undo: [

--- a/src/server/index.test.js
+++ b/src/server/index.test.js
@@ -150,42 +150,66 @@ test('sync', async () => {
   spy.mockRestore();
 });
 
-test('update', async () => {
+describe('update', async () => {
   const server = Server({ games: [game] });
   const io = server.app.context.io;
   const action = ActionCreators.gameEvent('endTurn');
 
-  await io.socket.receive('update', action);
-  expect(io.socket.emit).toHaveBeenCalledTimes(0);
-  io.socket.emit.mockReset();
+  beforeEach(() => {
+    io.socket.emit.mockReset();
+  });
 
-  await io.socket.receive('sync', 'gameID');
-  io.socket.id = 'second';
-  await io.socket.receive('sync', 'gameID');
-  io.socket.emit.mockReset();
+  describe('without clients connected', () => {
+    test('no updates sent', async () => {
+      await io.socket.receive('update', action);
+      expect(io.socket.emit).toHaveBeenCalledTimes(0);
+    });
+  });
 
-  // View-only players cannot send actions.
-  await io.socket.receive('update', action, 0, 'gameID', null);
-  expect(io.socket.emit).not.toHaveBeenCalled();
+  describe('with clients connected', () => {
+    beforeAll(async () => {
+      await io.socket.receive('sync', 'gameID');
+      io.socket.id = 'second';
+      await io.socket.receive('sync', 'gameID');
+      io.socket.emit.mockReset();
+    });
 
-  // Actions are broadcasted as state updates.
-  // The playerID parameter is necessary to account for view-only players.
-  await io.socket.receive('update', action, 0, 'gameID', '0');
-  expect(io.socket.emit).lastCalledWith(
-    'update',
-    'gameID',
-    {
-      G: {},
-      deltalog: undefined,
-      log: undefined,
-      _initial: {
-        G: {},
-        _initial: {},
-        _redo: [],
-        _stateID: 0,
-        _undo: [
-          {
+    test('basic', async () => {
+      await io.socket.receive('update', action, 0, 'gameID', '0');
+      expect(io.socket.emit).lastCalledWith(
+        'update',
+        'gameID',
+        {
+          G: {},
+          deltalog: undefined,
+          log: undefined,
+          _initial: {
             G: {},
+            _initial: {},
+            _redo: [],
+            _stateID: 0,
+            _undo: [
+              {
+                G: {},
+                ctx: {
+                  _random: { seed: 0 },
+                  actionPlayers: ['0'],
+                  allPlayed: false,
+                  allowedMoves: null,
+                  currentPlayer: '0',
+                  currentPlayerMoves: 0,
+                  numPlayers: 2,
+                  phase: 'default',
+                  playOrder: ['0', '1'],
+                  playOrderPos: 0,
+                  stats: {
+                    phase: { allPlayed: false, numMoves: {} },
+                    turn: { numMoves: {} },
+                  },
+                  turn: 0,
+                },
+              },
+            ],
             ctx: {
               _random: { seed: 0 },
               actionPlayers: ['0'],
@@ -199,37 +223,37 @@ test('update', async () => {
               playOrderPos: 0,
               stats: {
                 phase: { allPlayed: false, numMoves: {} },
-                turn: { numMoves: {} },
+                turn: { allPlayed: false, numMoves: {} },
               },
               turn: 0,
             },
           },
-        ],
-        ctx: {
-          _random: { seed: 0 },
-          actionPlayers: ['0'],
-          allPlayed: false,
-          allowedMoves: null,
-          currentPlayer: '0',
-          currentPlayerMoves: 0,
-          numPlayers: 2,
-          phase: 'default',
-          playOrder: ['0', '1'],
-          playOrderPos: 0,
-          stats: {
-            phase: { allPlayed: false, numMoves: {} },
-            turn: { allPlayed: false, numMoves: {} },
-          },
-          turn: 0,
-        },
-      },
-      _redo: [],
-      _stateID: 1,
-      _undo: [
-        {
-          G: {},
+          _redo: [],
+          _stateID: 1,
+          _undo: [
+            {
+              G: {},
+              ctx: {
+                _random: { seed: 0 },
+                actionPlayers: ['1'],
+                allPlayed: false,
+                allowedMoves: null,
+                currentPlayer: '1',
+                currentPlayerMoves: 0,
+                numPlayers: 2,
+                phase: 'default',
+                playOrder: ['0', '1'],
+                playOrderPos: 1,
+                stats: {
+                  phase: { allPlayed: false, numMoves: {} },
+                  turn: { allPlayed: false, numMoves: {} },
+                },
+                turn: 1,
+              },
+            },
+          ],
           ctx: {
-            _random: { seed: 0 },
+            _random: undefined,
             actionPlayers: ['1'],
             allPlayed: false,
             allowedMoves: null,
@@ -246,64 +270,51 @@ test('update', async () => {
             turn: 1,
           },
         },
-      ],
-      ctx: {
-        _random: undefined,
-        actionPlayers: ['1'],
-        allPlayed: false,
-        allowedMoves: null,
-        currentPlayer: '1',
-        currentPlayerMoves: 0,
-        numPlayers: 2,
-        phase: 'default',
-        playOrder: ['0', '1'],
-        playOrderPos: 1,
-        stats: {
-          phase: { allPlayed: false, numMoves: {} },
-          turn: { allPlayed: false, numMoves: {} },
-        },
-        turn: 1,
-      },
-    },
 
-    // deltalog
-    [
-      {
-        payload: {
-          args: undefined,
-          credentials: undefined,
-          playerID: undefined,
-          type: 'endTurn',
-        },
-        type: 'GAME_EVENT',
-      },
-    ]
-  );
-  io.socket.emit.mockReset();
+        // deltalog
+        [
+          {
+            payload: {
+              args: undefined,
+              credentials: undefined,
+              playerID: undefined,
+              type: 'endTurn',
+            },
+            type: 'GAME_EVENT',
+          },
+        ]
+      );
+      io.socket.emit.mockReset();
+    });
 
-  // ... but not if the gameID is not known.
-  await io.socket.receive('update', action, 1, 'unknown', '1');
-  expect(io.socket.emit).toHaveBeenCalledTimes(0);
+    test('invalid gameID', async () => {
+      await io.socket.receive('update', action, 1, 'unknown', '1');
+      expect(io.socket.emit).toHaveBeenCalledTimes(0);
+    });
 
-  // ... and not if the _stateID doesn't match the internal state.
-  await io.socket.receive('update', action, 100, 'gameID', '1');
-  expect(io.socket.emit).toHaveBeenCalledTimes(0);
+    test('invalid stateID', async () => {
+      await io.socket.receive('update', action, 100, 'gameID', '1');
+      expect(io.socket.emit).toHaveBeenCalledTimes(0);
+    });
 
-  // ... and not if player != currentPlayer
-  await io.socket.receive('update', action, 1, 'gameID', '100');
-  expect(io.socket.emit).toHaveBeenCalledTimes(0);
-  await io.socket.receive(
-    'update',
-    ActionCreators.makeMove(),
-    1,
-    'gameID',
-    '100'
-  );
-  expect(io.socket.emit).toHaveBeenCalledTimes(0);
+    test('invalid playerID', async () => {
+      await io.socket.receive('update', action, 1, 'gameID', '100');
+      expect(io.socket.emit).toHaveBeenCalledTimes(0);
+      await io.socket.receive(
+        'update',
+        ActionCreators.makeMove(),
+        1,
+        'gameID',
+        '100'
+      );
+      expect(io.socket.emit).toHaveBeenCalledTimes(0);
+    });
 
-  // Another broadcasted action.
-  await io.socket.receive('update', action, 1, 'gameID', '1');
-  expect(io.socket.emit).toHaveBeenCalledTimes(2);
+    test('valid gameID / stateID / playerID', async () => {
+      await io.socket.receive('update', action, 1, 'gameID', '1');
+      expect(io.socket.emit).toHaveBeenCalledTimes(2);
+    });
+  });
 });
 
 describe('playerView', () => {

--- a/src/server/index.test.js
+++ b/src/server/index.test.js
@@ -150,12 +150,12 @@ test('sync', async () => {
   spy.mockRestore();
 });
 
-test('action', async () => {
+test('update', async () => {
   const server = Server({ games: [game] });
   const io = server.app.context.io;
   const action = ActionCreators.gameEvent('endTurn');
 
-  await io.socket.receive('action', action);
+  await io.socket.receive('update', action);
   expect(io.socket.emit).toHaveBeenCalledTimes(0);
   io.socket.emit.mockReset();
 
@@ -165,56 +165,109 @@ test('action', async () => {
   io.socket.emit.mockReset();
 
   // View-only players cannot send actions.
-  await io.socket.receive('action', action, 0, 'gameID', null);
+  await io.socket.receive('update', action, 0, 'gameID', null);
   expect(io.socket.emit).not.toHaveBeenCalled();
 
   // Actions are broadcasted as state updates.
   // The playerID parameter is necessary to account for view-only players.
-  await io.socket.receive('action', action, 0, 'gameID', '0');
-  expect(io.socket.emit).lastCalledWith('sync', 'gameID', {
-    G: {},
-    _redo: [],
-    _stateID: 1,
-    _undo: [
-      {
+  await io.socket.receive('update', action, 0, 'gameID', '0');
+  expect(io.socket.emit).lastCalledWith(
+    'update',
+    'gameID',
+    {
+      G: {},
+      deltalog: undefined,
+      log: undefined,
+      _initial: {
         G: {},
+        _initial: {},
+        _redo: [],
+        _stateID: 0,
+        _undo: [
+          {
+            G: {},
+            ctx: {
+              _random: { seed: 0 },
+              actionPlayers: ['0'],
+              allPlayed: false,
+              allowedMoves: null,
+              currentPlayer: '0',
+              currentPlayerMoves: 0,
+              numPlayers: 2,
+              phase: 'default',
+              playOrder: ['0', '1'],
+              playOrderPos: 0,
+              stats: {
+                phase: { allPlayed: false, numMoves: {} },
+                turn: { numMoves: {} },
+              },
+              turn: 0,
+            },
+          },
+        ],
         ctx: {
           _random: { seed: 0 },
-          actionPlayers: ['1'],
+          actionPlayers: ['0'],
           allPlayed: false,
           allowedMoves: null,
-          currentPlayer: '1',
+          currentPlayer: '0',
           currentPlayerMoves: 0,
           numPlayers: 2,
           phase: 'default',
           playOrder: ['0', '1'],
-          playOrderPos: 1,
+          playOrderPos: 0,
           stats: {
             phase: { allPlayed: false, numMoves: {} },
             turn: { allPlayed: false, numMoves: {} },
           },
-          turn: 1,
+          turn: 0,
         },
       },
-    ],
-    ctx: {
-      _random: undefined,
-      actionPlayers: ['1'],
-      allPlayed: false,
-      allowedMoves: null,
-      currentPlayer: '1',
-      currentPlayerMoves: 0,
-      numPlayers: 2,
-      phase: 'default',
-      playOrder: ['0', '1'],
-      playOrderPos: 1,
-      stats: {
-        phase: { allPlayed: false, numMoves: {} },
-        turn: { allPlayed: false, numMoves: {} },
+      _redo: [],
+      _stateID: 1,
+      _undo: [
+        {
+          G: {},
+          ctx: {
+            _random: { seed: 0 },
+            actionPlayers: ['1'],
+            allPlayed: false,
+            allowedMoves: null,
+            currentPlayer: '1',
+            currentPlayerMoves: 0,
+            numPlayers: 2,
+            phase: 'default',
+            playOrder: ['0', '1'],
+            playOrderPos: 1,
+            stats: {
+              phase: { allPlayed: false, numMoves: {} },
+              turn: { allPlayed: false, numMoves: {} },
+            },
+            turn: 1,
+          },
+        },
+      ],
+      ctx: {
+        _random: undefined,
+        actionPlayers: ['1'],
+        allPlayed: false,
+        allowedMoves: null,
+        currentPlayer: '1',
+        currentPlayerMoves: 0,
+        numPlayers: 2,
+        phase: 'default',
+        playOrder: ['0', '1'],
+        playOrderPos: 1,
+        stats: {
+          phase: { allPlayed: false, numMoves: {} },
+          turn: { allPlayed: false, numMoves: {} },
+        },
+        turn: 1,
       },
-      turn: 1,
     },
-    deltalog: [
+
+    // deltalog
+    [
       {
         payload: {
           args: undefined,
@@ -224,23 +277,23 @@ test('action', async () => {
         },
         type: 'GAME_EVENT',
       },
-    ],
-  });
+    ]
+  );
   io.socket.emit.mockReset();
 
   // ... but not if the gameID is not known.
-  await io.socket.receive('action', action, 1, 'unknown', '1');
+  await io.socket.receive('update', action, 1, 'unknown', '1');
   expect(io.socket.emit).toHaveBeenCalledTimes(0);
 
   // ... and not if the _stateID doesn't match the internal state.
-  await io.socket.receive('action', action, 100, 'gameID', '1');
+  await io.socket.receive('update', action, 100, 'gameID', '1');
   expect(io.socket.emit).toHaveBeenCalledTimes(0);
 
   // ... and not if player != currentPlayer
-  await io.socket.receive('action', action, 1, 'gameID', '100');
+  await io.socket.receive('update', action, 1, 'gameID', '100');
   expect(io.socket.emit).toHaveBeenCalledTimes(0);
   await io.socket.receive(
-    'action',
+    'update',
     ActionCreators.makeMove(),
     1,
     'gameID',
@@ -249,7 +302,7 @@ test('action', async () => {
   expect(io.socket.emit).toHaveBeenCalledTimes(0);
 
   // Another broadcasted action.
-  await io.socket.receive('action', action, 1, 'gameID', '1');
+  await io.socket.receive('update', action, 1, 'gameID', '1');
   expect(io.socket.emit).toHaveBeenCalledTimes(2);
 });
 
@@ -270,7 +323,7 @@ describe('playerView', () => {
     expect(io.socket.emit.mock.calls[0][2].G).toEqual({ player: 0 });
   });
 
-  test('action', async () => {
+  test('update', async () => {
     const game = Game({
       playerView: (G, ctx, player) => {
         return Object.assign({}, G, { player });
@@ -286,7 +339,7 @@ describe('playerView', () => {
     await io.socket.receive('sync', 'gameID', '1', 2);
     io.socket.emit.mockReset();
 
-    await io.socket.receive('action', action, 0, 'gameID', '0');
+    await io.socket.receive('update', action, 0, 'gameID', '0');
     expect(io.socket.emit).toHaveBeenCalledTimes(2);
 
     const G_player0 = io.socket.emit.mock.calls[0][2].G;
@@ -334,154 +387,6 @@ test('auth failure', async () => {
   await io.socket.receive('sync', 'gameID');
   io.socket.emit.mockReset();
 
-  await io.socket.receive('action', action, 0, 'gameID', '0');
+  await io.socket.receive('update', action, 0, 'gameID', '0');
   expect(io.socket.emit).toHaveBeenCalledTimes(0);
-});
-
-test('delta log', async () => {
-  const server = Server({ games: [game] });
-  const io = server.app.context.io;
-  const action = ActionCreators.gameEvent('endTurn');
-
-  await io.socket.receive('sync', 'gameID');
-  io.socket.id = 'second';
-  await io.socket.receive('sync', 'gameID');
-  io.socket.emit.mockReset();
-
-  await io.socket.receive('action', action, 0, 'gameID', '0');
-  expect(io.socket.emit).lastCalledWith('sync', 'gameID', {
-    G: {},
-    _redo: [],
-    _stateID: 1,
-    _undo: [
-      {
-        G: {},
-        ctx: {
-          _random: { seed: 0 },
-          actionPlayers: ['1'],
-          allPlayed: false,
-          allowedMoves: null,
-          currentPlayer: '1',
-          currentPlayerMoves: 0,
-          numPlayers: 2,
-          phase: 'default',
-          playOrder: ['0', '1'],
-          playOrderPos: 1,
-          stats: {
-            phase: { allPlayed: false, numMoves: {} },
-            turn: { allPlayed: false, numMoves: {} },
-          },
-          turn: 1,
-        },
-      },
-    ],
-    ctx: {
-      _random: undefined,
-      actionPlayers: ['1'],
-      allPlayed: false,
-      allowedMoves: null,
-      currentPlayer: '1',
-      currentPlayerMoves: 0,
-      numPlayers: 2,
-      phase: 'default',
-      playOrder: ['0', '1'],
-      playOrderPos: 1,
-      stats: {
-        phase: { allPlayed: false, numMoves: {} },
-        turn: { allPlayed: false, numMoves: {} },
-      },
-      turn: 1,
-    },
-    deltalog: [
-      {
-        payload: {
-          args: undefined,
-          credentials: undefined,
-          playerID: undefined,
-          type: 'endTurn',
-        },
-        type: 'GAME_EVENT',
-      },
-    ],
-  });
-  io.socket.emit.mockReset();
-
-  await io.socket.receive('action', action, 1, 'gameID', '1');
-  expect(io.socket.emit).lastCalledWith('sync', 'gameID', {
-    G: {},
-    _initial: undefined,
-    _redo: [],
-    _stateID: 2,
-    _undo: [
-      {
-        G: {},
-        ctx: {
-          _random: { seed: 0 },
-          actionPlayers: ['0'],
-          allPlayed: false,
-          allowedMoves: null,
-          currentPlayer: '0',
-          currentPlayerMoves: 0,
-          numPlayers: 2,
-          phase: 'default',
-          playOrder: ['0', '1'],
-          playOrderPos: 0,
-          stats: {
-            phase: { allPlayed: false, numMoves: {} },
-            turn: { allPlayed: false, numMoves: {} },
-          },
-          turn: 2,
-        },
-      },
-    ],
-    ctx: {
-      _random: undefined,
-      actionPlayers: ['0'],
-      allPlayed: false,
-      allowedMoves: null,
-      currentPlayer: '0',
-      currentPlayerMoves: 0,
-      numPlayers: 2,
-      phase: 'default',
-      playOrder: ['0', '1'],
-      playOrderPos: 0,
-      stats: {
-        phase: { allPlayed: false, numMoves: {} },
-        turn: { allPlayed: false, numMoves: {} },
-      },
-      turn: 2,
-    },
-    deltalog: [
-      {
-        payload: {
-          args: undefined,
-          credentials: undefined,
-          playerID: undefined,
-          type: 'endTurn',
-        },
-        type: 'GAME_EVENT',
-      },
-    ],
-    log: undefined,
-  });
-  io.socket.emit.mockReset();
-
-  // the complete log has two entries
-  await io.socket.receive('sync', 'gameID', null);
-  // get third argument of the first call
-  const transferState = io.socket.emit.mock.calls[0][2];
-  expect(transferState.log).toMatchObject([
-    {
-      payload: {
-        type: 'endTurn',
-      },
-      type: 'GAME_EVENT',
-    },
-    {
-      payload: {
-        type: 'endTurn',
-      },
-      type: 'GAME_EVENT',
-    },
-  ]);
 });


### PR DESCRIPTION
This PR implements part 3 of #227 (deltalog).

The server's reaction to an `action` command is changed and only added log entries are transferred (the `deltalog`). At client side, the deltalog is added to the current state`s log again.

`_initial` is stripped from `action` commands since it's only necessary to transfer it once during the initial `sync` to the server. It also gets added at client side.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
