### PR TITLE
use patch-1 of graceful-fs to avoid jest cache errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7006,9 +7006,8 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "git+https://github.com/mekwall/node-graceful-fs.git#a10aa576f771d7cf3dfaee523f2e02d6eb11a89f",
+      "from": "git+https://github.com/mekwall/node-graceful-fs.git#patch-1",
       "dev": true
     },
     "growly": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "superagent": "^3.8.3",
     "supertest": "^3.1.0",
     "uglify-es": "^3.1.3",
-    "webpack": "^3.5.5"
+    "webpack": "^3.5.5",
+    "graceful-fs": "https://github.com/mekwall/node-graceful-fs.git#patch-1"
   },
   "dependencies": {
     "@koa/cors": "^2.2.1",


### PR DESCRIPTION
Please see #254 for details.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
