### PR TITLE
Prep for GameLog stuff: Introduce ContextEnhancer

### DIFF
--- a/src/core/random.js
+++ b/src/core/random.js
@@ -32,8 +32,10 @@ export class Random {
    * Updates ctx with the PRNG state.
    * @param {object} ctx - The ctx object to update.
    */
-  update(ctx) {
-    return { ...ctx, _random: this.state };
+  update(state) {
+    var newCtx = { ...state.ctx, _random: this.state };
+    var newState = { ...state, ctx: newCtx };
+    return newState;
   }
 
   /**

--- a/src/core/random.test.js
+++ b/src/core/random.test.js
@@ -35,7 +35,7 @@ test('attach / detach / update', () => {
   }
 
   {
-    const t = r.update(ctx);
+    const t = r.update({ ctx }).ctx;
     expect(t._random).toBeDefined();
     expect(t.random).toBeDefined();
   }

--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -67,7 +67,7 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
   initial.G = state.G;
   initial._undo = state._undo;
   initial.ctx = ctxWithEvents;
-  initial.ctx = random.update(initial.ctx);
+  initial.ctx = random.update(initial).ctx;
   initial.ctx = Random.detach(initial.ctx);
   initial.ctx = Events.detach(initial.ctx);
 
@@ -121,7 +121,7 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
         // Trigger any events that were called via the Events API.
         newState = events.update(newState);
         // Update ctx with PRNG state.
-        let ctx = random.update(newState.ctx);
+        let ctx = random.update(newState).ctx;
         // Detach Random API from ctx.
         ctx = Random.detach(ctx);
         // Detach Events API from ctx.
@@ -173,7 +173,7 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
         }
 
         // Update ctx with PRNG state.
-        let ctx = random.update(state.ctx);
+        let ctx = random.update(state).ctx;
         // Detach Random API from ctx.
         ctx = Random.detach(ctx);
         // Detach Events API from ctx.
@@ -203,7 +203,7 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
         state = { ...state, ctx: events.attach(state.ctx) };
         state = game.flow.processMove(state, action.payload);
         state = events.update(state);
-        state = { ...state, ctx: random.update(state.ctx) };
+        state = random.update(state);
         state = { ...state, ctx: Random.detach(state.ctx) };
         state = { ...state, ctx: Events.detach(state.ctx) };
 


### PR DESCRIPTION
This PR is written as prep work for #227, where we want to attach a `log` object to the context, allowing a game to write custom logging information. It introduces a class called `ContextEnhancer` that ties all APIs together that can be attached and detached from a context - currently, these are `random` and `events`. This results in
* less code duplication
* easier attaching of new APIs.

Albeit I failed to also fixup the code creating the initial state, I've not exactly pinpointed why using `ctxApi.update()` does not work. The flow of the various state and context objects gets unwieldy, too. And perhaps there are other places that could use that class also.

Let me know what you think.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
