### PR TITLE
Allow to set payload onto a log event

### DIFF
--- a/examples/react/modules/tic-tac-toe/game.js
+++ b/examples/react/modules/tic-tac-toe/game.js
@@ -48,6 +48,9 @@ const TicTacToe = Game({
 
       if (cells[id] === null) {
         cells[id] = ctx.currentPlayer;
+        ctx.log.setPayload({
+          date: new Date().toUTCString(),
+        });
       }
 
       return { ...G, cells };

--- a/src/client/log/log.css
+++ b/src/client/log/log.css
@@ -9,7 +9,7 @@
 .gamelog {
   display: grid;
   grid-template-columns: 30px 1fr 30px;
-  :grid-auto-rows: auto;
+  grid-auto-rows: auto;
   grid-auto-flow: column;
 }
 
@@ -39,7 +39,7 @@
   text-align: center;
   color: #888;
   font-size: 14px;
-  height: 25px;
+  min-height: 25px;
   line-height: 25px;
 }
 
@@ -55,6 +55,7 @@
   text-orientation: sideways;
   writing-mode: vertical-rl;
   line-height: 30px;
+  width: 100%;
 }
 
 .gamelog.pinned .log-event {

--- a/src/client/log/log.js
+++ b/src/client/log/log.js
@@ -28,7 +28,7 @@ const LogEvent = props => {
 
   const custompayload =
     props.payload !== undefined
-      ? 'payload: ' + JSON.stringify(props.payload, null, 4)
+      ? ', payload: ' + JSON.stringify(props.payload, null, 4)
       : '';
 
   return (

--- a/src/client/log/log.js
+++ b/src/client/log/log.js
@@ -26,6 +26,11 @@ const LogEvent = props => {
     classNames += ' pinned';
   }
 
+  const custompayload =
+    props.payload !== undefined
+      ? 'payload: ' + JSON.stringify(props.payload, null, 4)
+      : '';
+
   return (
     <div
       className={classNames}
@@ -34,12 +39,14 @@ const LogEvent = props => {
       onMouseLeave={() => props.onMouseLeave()}
     >
       {action.payload.type}({args.join(',')})
+      {custompayload}
     </div>
   );
 };
 
 LogEvent.propTypes = {
   action: PropTypes.any.isRequired,
+  payload: PropTypes.object,
   logIndex: PropTypes.number.isRequired,
   onLogClick: PropTypes.func.isRequired,
   onMouseEnter: PropTypes.func.isRequired,
@@ -165,7 +172,7 @@ export class GameLog extends React.Component {
     }
 
     for (let i = 0; i < this.props.log.length; i++) {
-      const { action } = this.props.log[i];
+      const { action, payload } = this.props.log[i];
       const oldTurn = state.ctx.turn;
       const oldPhase = state.ctx.phase;
 
@@ -179,6 +186,7 @@ export class GameLog extends React.Component {
             onMouseEnter={this.onMouseEnter}
             onMouseLeave={this.onMouseLeave}
             action={action}
+            payload={payload}
           />
         );
 

--- a/src/client/log/log.js
+++ b/src/client/log/log.js
@@ -12,6 +12,18 @@ import { MAKE_MOVE } from '../../core/action-types';
 import './log.css';
 
 /**
+ * Default component to render custom payload.
+ */
+const CustomPayload = props => {
+  const custompayload =
+    props.payload !== undefined ? JSON.stringify(props.payload, null, 4) : '';
+  return <div>{custompayload}</div>;
+};
+CustomPayload.propTypes = {
+  payload: PropTypes.any,
+};
+
+/**
  * LogEvent
  *
  * Logs a single action in the game.
@@ -26,8 +38,13 @@ const LogEvent = props => {
     classNames += ' pinned';
   }
 
-  const custompayload =
-    props.payload !== undefined ? JSON.stringify(props.payload, null, 4) : '';
+  // allow to pass in custom rendering component for custom payload
+  const customPayload =
+    props.payloadComponent !== undefined ? (
+      React.createElement(props.payloadComponent, { payload: props.payload })
+    ) : (
+      <CustomPayload payload={props.payload} />
+    );
 
   return (
     <div
@@ -39,19 +56,20 @@ const LogEvent = props => {
       <div>
         {action.payload.type}({args.join(',')})
       </div>
-      <div>{custompayload}</div>
+      {customPayload}
     </div>
   );
 };
 
 LogEvent.propTypes = {
   action: PropTypes.any.isRequired,
-  payload: PropTypes.object,
   logIndex: PropTypes.number.isRequired,
   onLogClick: PropTypes.func.isRequired,
   onMouseEnter: PropTypes.func.isRequired,
   onMouseLeave: PropTypes.func.isRequired,
   pinned: PropTypes.bool,
+  payload: PropTypes.object,
+  payloadComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
 };
 
 /**
@@ -106,6 +124,7 @@ export class GameLog extends React.Component {
     reducer: PropTypes.func,
     initialState: PropTypes.any.isRequired,
     log: PropTypes.array.isRequired,
+    payloadComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   };
 
   static defaultProps = {
@@ -187,6 +206,7 @@ export class GameLog extends React.Component {
             onMouseLeave={this.onMouseLeave}
             action={action}
             payload={payload}
+            payloadComponent={this.props.payloadComponent}
           />
         );
 

--- a/src/client/log/log.js
+++ b/src/client/log/log.js
@@ -27,9 +27,7 @@ const LogEvent = props => {
   }
 
   const custompayload =
-    props.payload !== undefined
-      ? ', payload: ' + JSON.stringify(props.payload, null, 4)
-      : '';
+    props.payload !== undefined ? JSON.stringify(props.payload, null, 4) : '';
 
   return (
     <div
@@ -38,8 +36,10 @@ const LogEvent = props => {
       onMouseEnter={() => props.onMouseEnter(props.logIndex)}
       onMouseLeave={() => props.onMouseLeave()}
     >
-      {action.payload.type}({args.join(',')})
-      {custompayload}
+      <div>
+        {action.payload.type}({args.join(',')})
+      </div>
+      <div>{custompayload}</div>
     </div>
   );
 };

--- a/src/client/log/log.test.js
+++ b/src/client/log/log.test.js
@@ -37,6 +37,18 @@ describe('layout', () => {
     expect(turns).toEqual(['0', '1']);
   });
 
+  test('payload', () => {
+    const log = [
+      { action: makeMove('moveA'), payload: { test_payload: 'payload123' } },
+    ];
+
+    const root = Enzyme.mount(
+      <GameLog log={log} initialState={state} reducer={reducer} />
+    );
+    const turns = root.find('.log-event').map(div => div.text());
+    expect(turns[0]).toContain('payload123');
+  });
+
   test('multiple moves per turn / phase', () => {
     const log = [
       { action: makeMove('moveA') },

--- a/src/client/log/log.test.js
+++ b/src/client/log/log.test.js
@@ -37,18 +37,6 @@ describe('layout', () => {
     expect(turns).toEqual(['0', '1']);
   });
 
-  test('payload', () => {
-    const log = [
-      { action: makeMove('moveA'), payload: { test_payload: 'payload123' } },
-    ];
-
-    const root = Enzyme.mount(
-      <GameLog log={log} initialState={state} reducer={reducer} />
-    );
-    const turns = root.find('.log-event').map(div => div.text());
-    expect(turns[0]).toContain('payload123');
-  });
-
   test('multiple moves per turn / phase', () => {
     const log = [
       { action: makeMove('moveA') },
@@ -238,5 +226,44 @@ describe('pinning', () => {
       .at(0)
       .simulate('mouseleave');
     expect(onHover).not.toHaveBeenCalled();
+  });
+});
+
+describe('payload', () => {
+  const game = Game({ flow: { phases: [{ name: 'A' }, { name: 'B' }] } });
+  const reducer = CreateGameReducer({ game });
+  const state = reducer(undefined, { type: 'init' });
+
+  const log = [
+    { action: makeMove('moveA'), payload: { test_payload: 'payload123' } },
+  ];
+
+  test('renders custom payload using the default component', () => {
+    const root = Enzyme.mount(
+      <GameLog log={log} initialState={state} reducer={reducer} />
+    );
+    const turns = root.find('.log-event').map(div => div.text());
+    expect(turns[0]).toContain('payload123');
+  });
+
+  test('renders custom payload using a custom component', () => {
+    const log = [
+      { action: makeMove('moveA'), payload: { test_payload: 'payload123' } },
+    ];
+
+    const customPayloadComponent = () => {
+      return <div>ignoring props.payload</div>;
+    };
+
+    const root = Enzyme.mount(
+      <GameLog
+        log={log}
+        initialState={state}
+        reducer={reducer}
+        payloadComponent={customPayloadComponent}
+      />
+    );
+    const turns = root.find('.log-event').map(div => div.text());
+    expect(turns[0]).toContain('ignoring props.payload');
   });
 });

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -12,9 +12,8 @@ import {
   UpdateTurnOrderState,
   TurnOrder,
 } from './turn-order';
-import { Random } from './random';
-import { Events } from './events';
 import { automaticGameEvent } from './action-creators';
+import { ContextEnhancer } from './reducer';
 
 /**
  * Helper to create a reducer that manages ctx (with the
@@ -365,9 +364,7 @@ export function FlowWithPhases({
   const startTurn = function(state, config) {
     const G = config.onTurnBegin(state.G, state.ctx);
 
-    let plainCtx = state.ctx;
-    plainCtx = Random.detach(plainCtx);
-    plainCtx = Events.detach(plainCtx);
+    const plainCtx = ContextEnhancer.detachAllFromContext(state.ctx);
     const _undo = [{ G, ctx: plainCtx }];
 
     const ctx = { ...state.ctx };
@@ -604,9 +601,7 @@ export function FlowWithPhases({
       const undo = state._undo || [];
       const moveType = action.type;
 
-      let plainCtx = state.ctx;
-      plainCtx = Random.detach(plainCtx);
-      plainCtx = Events.detach(plainCtx);
+      const plainCtx = ContextEnhancer.detachAllFromContext(state.ctx);
 
       state = {
         ...state,

--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -30,6 +30,7 @@ export class GameLoggerCtxAPI {
   attach(ctx) {
     return { ...ctx, log: this._api() };
   }
+
   update(state) {
     if (this._payload === undefined) {
       return state;
@@ -43,9 +44,9 @@ export class GameLoggerCtxAPI {
     };
     this._payload = undefined;
 
-    const newState = { ...state, deltalog };
-    return newState;
+    return { ...state, deltalog };
   }
+
   static detach(ctx) {
     const { log, ...ctxWithoutLog } = ctx; // eslint-disable-line no-unused-vars
     return ctxWithoutLog;

--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -14,7 +14,7 @@ import { Events } from './events';
 /**
  * Context API to allow writing custom logs in games.
  */
-export class GameLoggerCtxApi {
+export class GameLoggerCtxAPI {
   constructor() {
     this._payload = undefined;
   }
@@ -61,7 +61,7 @@ export class ContextEnhancer {
   constructor(ctx, game, player) {
     this.random = new Random(ctx);
     this.events = new Events(game.flow, player);
-    this.log = new GameLoggerCtxApi();
+    this.log = new GameLoggerCtxAPI();
   }
 
   attachToContext(ctx) {
@@ -74,7 +74,7 @@ export class ContextEnhancer {
   static detachAllFromContext(ctx) {
     let ctxWithoutAPI = Random.detach(ctx);
     ctxWithoutAPI = Events.detach(ctxWithoutAPI);
-    ctxWithoutAPI = GameLoggerCtxApi.detach(ctxWithoutAPI);
+    ctxWithoutAPI = GameLoggerCtxAPI.detach(ctxWithoutAPI);
     return ctxWithoutAPI;
   }
 

--- a/src/core/reducer.test.js
+++ b/src/core/reducer.test.js
@@ -328,3 +328,20 @@ test('undo / redo', () => {
   state = reducer(state, undo());
   expect(state.G).toEqual({ A: true });
 });
+
+test('custom log messages', () => {
+  let game = Game({
+    moves: {
+      move: (G, ctx) => {
+        ctx.log.setPayload({ msg: 'additional msg' });
+        return { ...G };
+      },
+    },
+  });
+
+  const reducer = CreateGameReducer({ game, numPlayers: 2 });
+  let state = reducer(undefined, { type: 'init' });
+
+  const newState = reducer(state, makeMove('move'));
+  expect(newState.deltalog[0].payload).toMatchObject({ msg: 'additional msg' });
+});


### PR DESCRIPTION
This PR is part of #227. It allows to actually set a log payload from a move and have it visualized. I've modified the `clickCell` method on the Tic-Tac-Toe example to set a payload.

@nicolodavis Please have a look at the visualization - I played around with the CSS (`overflow` and the fixed height) to no avail; perhaps you have a suggestion on how to visualize a payload.

![grafik](https://user-images.githubusercontent.com/1977938/44674272-486aa900-aa2d-11e8-89ec-7bcc217d07c8.png)


#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
