### PR TITLE
add allOthers option to setActionPlayers

### DIFF
--- a/examples/react/modules/turnorder/components/board.js
+++ b/examples/react/modules/turnorder/components/board.js
@@ -69,8 +69,7 @@ const Board = ({ ctx, G, playerID, events, moves }) => {
       <button
         disabled={!canDrop}
         onClick={() => {
-          let ap = ctx.actionPlayers.filter(nr => nr !== playerID);
-          events.changeActionPlayers(ap);
+          moves.dropCards();
         }}
       >
         Drop Cards
@@ -92,6 +91,7 @@ const Board = ({ ctx, G, playerID, events, moves }) => {
       <span>
         <div>{playerData.name}</div>
         <div>Actions: {playerData.actions}</div>
+        <div>Cards: {playerData.cards}</div>
       </span>
       {buttons}
       {currentPlayer}

--- a/examples/react/modules/turnorder/components/board.js
+++ b/examples/react/modules/turnorder/components/board.js
@@ -55,7 +55,8 @@ const Board = ({ ctx, G, playerID, events, moves }) => {
 
   const deepEquals = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 
-  const canEndTurn = deepEquals(ctx.actionPlayers, [playerID]);
+  const canEndTurn =
+    deepEquals(ctx.actionPlayers, [playerID]) && playerID === ctx.currentPlayer;
   const canDrop =
     ctx.actionPlayers.includes(playerID) && ctx.currentPlayer != playerID;
   const canPlay = canEndTurn && playerData.actions > 0;

--- a/examples/react/modules/turnorder/game.js
+++ b/examples/react/modules/turnorder/game.js
@@ -15,14 +15,17 @@ const TurnExample = Game({
     players: [
       {
         name: 'Player 1',
+        cards: 5,
         actions: 0,
       },
       {
         name: 'Player 2',
+        cards: 5,
         actions: 0,
       },
       {
         name: 'Player 3',
+        cards: 5,
         actions: 0,
       },
     ],
@@ -30,9 +33,9 @@ const TurnExample = Game({
 
   moves: {
     playMilitia: (G, ctx) => {
-      // Need to keep the currentPlayer inside actionPlayers - otherwise
-      // he will not be able to make any move anymore.
-      ctx.events.setActionPlayers(['0', '1', '2']);
+      ctx.events.setActionPlayers(
+        ['0', '1', '2'].filter(nr => +nr !== +ctx.currentPlayer)
+      );
 
       const currentPlayer = ctx.currentPlayer;
       const playersNext = [...G.players];
@@ -40,6 +43,25 @@ const TurnExample = Game({
 
       const nextG = { players: playersNext };
       return nextG;
+    },
+
+    dropCards: (G, ctx) => {
+      const ap = ctx.actionPlayers.filter(nr => +nr !== +ctx.playerID);
+
+      if (ap.length !== 0) {
+        // there are still players needing to take action
+        ctx.events.setActionPlayers(ap);
+      } else {
+        // all players dropped cards => give control back to the current player
+        ctx.events.setActionPlayers([ctx.currentPlayer]);
+      }
+
+      const newPlayer = { ...G.players[+ctx.playerID], cards: 3 };
+      // TODO functional approach to replace element from array?
+      const newPlayers = [...G.players];
+      newPlayers[+ctx.playerID] = newPlayer;
+
+      return { ...G, players: newPlayers };
     },
   },
 

--- a/examples/react/modules/turnorder/game.js
+++ b/examples/react/modules/turnorder/game.js
@@ -33,9 +33,7 @@ const TurnExample = Game({
 
   moves: {
     playMilitia: (G, ctx) => {
-      ctx.events.setActionPlayers(
-        ['0', '1', '2'].filter(nr => +nr !== +ctx.currentPlayer)
-      );
+      ctx.events.setActionPlayers({ allOthers: true });
 
       const currentPlayer = ctx.currentPlayer;
       const playersNext = [...G.players];
@@ -46,16 +44,6 @@ const TurnExample = Game({
     },
 
     dropCards: (G, ctx) => {
-      const ap = ctx.actionPlayers.filter(nr => +nr !== +ctx.playerID);
-
-      if (ap.length !== 0) {
-        // there are still players needing to take action
-        ctx.events.setActionPlayers(ap);
-      } else {
-        // all players dropped cards => give control back to the current player
-        ctx.events.setActionPlayers([ctx.currentPlayer]);
-      }
-
       const newPlayer = { ...G.players[+ctx.playerID], cards: 3 };
       // TODO functional approach to replace element from array?
       const newPlayers = [...G.players];

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -101,7 +101,8 @@ export function Flow({
     optimisticUpdate,
 
     canPlayerCallEvent: (G, ctx, playerID) => {
-      return ctx.currentPlayer == playerID;
+      const actionPlayers = ctx.actionPlayers || [];
+      return ctx.currentPlayer == playerID || actionPlayers.includes(playerID);
     },
 
     canPlayerMakeMove: (G, ctx, playerID) => {

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -551,9 +551,16 @@ export function FlowWithPhases({
 
     // Update actionPlayers if _actionPlayersOnce is set.
     let actionPlayers = state.ctx.actionPlayers;
-    if (state.ctx._actionPlayersOnce == true) {
+    if (state.ctx._actionPlayersOnce) {
       const playerID = action.playerID;
       actionPlayers = actionPlayers.filter(id => id !== playerID);
+    }
+    if (state.ctx._actionPlayersAllOthers) {
+      const playerID = action.playerID;
+      actionPlayers = actionPlayers.filter(id => id !== playerID);
+      if (actionPlayers.length === 0) {
+        actionPlayers = [state.ctx.currentPlayer];
+      }
     }
 
     state = {

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -101,8 +101,7 @@ export function Flow({
     optimisticUpdate,
 
     canPlayerCallEvent: (G, ctx, playerID) => {
-      const actionPlayers = ctx.actionPlayers || [];
-      return ctx.currentPlayer == playerID || actionPlayers.includes(playerID);
+      return ctx.currentPlayer == playerID;
     },
 
     canPlayerMakeMove: (G, ctx, playerID) => {

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -510,7 +510,7 @@ test('canPlayerCallEvent', () => {
     false
   );
   expect(flow.canPlayerCallEvent({}, { actionPlayers: ['0'] }, playerID)).toBe(
-    true
+    false
   );
 });
 

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -479,21 +479,39 @@ test('canMakeMove', () => {
 });
 
 test('canPlayerMakeMove', () => {
-  // default behaviour
-  const pid = '0';
+  const playerID = '0';
 
   let flow = Flow({});
-  expect(flow.canPlayerMakeMove({}, {}, pid)).toBe(false);
+  expect(flow.canPlayerMakeMove({}, {}, playerID)).toBe(false);
   // NOTE: currentPlayer is not allowed to make a move by default.
   // Their playerID must be included in the actionPlayers array.
-  expect(flow.canPlayerMakeMove({}, { actionPlayers: ['1'] }, pid)).toBe(false);
-  expect(flow.canPlayerMakeMove({}, { actionPlayers: ['0'] }, pid)).toBe(true);
+  expect(flow.canPlayerMakeMove({}, { actionPlayers: ['1'] }, playerID)).toBe(
+    false
+  );
+  expect(flow.canPlayerMakeMove({}, { actionPlayers: ['0'] }, playerID)).toBe(
+    true
+  );
 
   // no one can make a move
   flow = Flow({ canPlayerMakeMove: () => false });
-  expect(flow.canPlayerMakeMove({}, {}, pid)).toBe(false);
-  expect(flow.canPlayerMakeMove({}, { actionPlayers: [] }, pid)).toBe(false);
+  expect(flow.canPlayerMakeMove({}, {}, playerID)).toBe(false);
+  expect(flow.canPlayerMakeMove({}, { actionPlayers: [] }, playerID)).toBe(
+    false
+  );
   expect(flow.canPlayerMakeMove({}, {}, '5')).toBe(false);
+});
+
+test('canPlayerCallEvent', () => {
+  const playerID = '0';
+
+  let flow = Flow({});
+  expect(flow.canPlayerCallEvent({}, {}, playerID)).toBe(false);
+  expect(flow.canPlayerCallEvent({}, { actionPlayers: ['1'] }, playerID)).toBe(
+    false
+  );
+  expect(flow.canPlayerCallEvent({}, { actionPlayers: ['0'] }, playerID)).toBe(
+    true
+  );
 });
 
 test('endGame', () => {

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -38,19 +38,19 @@ export const Pass = (G, ctx) => {
  *   }
  */
 export function SetActionPlayers(state, arg) {
-  let _actionPlayersOnce = false;
   let actionPlayers = [];
-
-  if (arg.once) {
-    _actionPlayersOnce = true;
-  }
 
   if (arg.value) {
     actionPlayers = arg.value;
   }
-
   if (arg.all) {
     actionPlayers = [...state.ctx.playOrder];
+  }
+
+  if (arg.allOthers) {
+    actionPlayers = [...state.ctx.playOrder].filter(
+      nr => nr !== state.ctx.currentPlayer
+    );
   }
 
   if (Array.isArray(arg)) {
@@ -59,7 +59,12 @@ export function SetActionPlayers(state, arg) {
 
   return {
     ...state,
-    ctx: { ...state.ctx, actionPlayers, _actionPlayersOnce },
+    ctx: {
+      ...state.ctx,
+      actionPlayers,
+      _actionPlayersOnce: arg.once,
+      _actionPlayersAllOthers: arg.allOthers,
+    },
   };
 }
 

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -235,6 +235,41 @@ describe('SetActionPlayers', () => {
     expect(state.ctx.actionPlayers).toEqual([]);
   });
 
+  test('allOthers', () => {
+    const game = Game({
+      flow: {
+        setActionPlayers: true,
+      },
+
+      moves: {
+        B: (G, ctx) => {
+          ctx.events.setActionPlayers({
+            value: ['0', '1', '2'],
+            allOthers: true,
+          });
+          return G;
+        },
+        A: G => G,
+      },
+    });
+
+    const reducer = CreateGameReducer({ game, numPlayers: 3 });
+
+    let state = reducer(undefined, { type: 'init' });
+
+    // on move B, control switches from player 0 to players 1 and 2
+    state = reducer(state, makeMove('B', null, '0'));
+    expect(state.ctx.actionPlayers).toEqual(['1', '2']);
+
+    // player 1 makes move
+    state = reducer(state, makeMove('A', null, '1'));
+    expect(state.ctx.actionPlayers).toEqual(['2']);
+
+    // player 1 makes move - after that, control should return to player 0
+    state = reducer(state, makeMove('A', null, '2'));
+    expect(state.ctx.actionPlayers).toEqual(['0']);
+  });
+
   test('militia', () => {
     const game = Game({
       flow: { setActionPlayers: true },


### PR DESCRIPTION
This PR fixes the militia example (see #154, part 5).

There are now two moves (_playMilitia_ and _dropCards_). For dropping cards to work for players that are action players but not the current player, I had to allow calling events for those players, because otherwise they would not be allowed to change action players.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
