### PR TITLE
server: add new API endpoints 'list' and 'leave'

### DIFF
--- a/src/server/db/firebase.js
+++ b/src/server/db/firebase.js
@@ -151,4 +151,42 @@ export class Firebase {
 
     return exists;
   }
+
+  /**
+   * Remove the game state from the DB.
+   * @param {string} id - The game id.
+   */
+  async remove(id) {
+    if (!await this.has(id)) return;
+
+    let col;
+    if (this.engine === ENGINE_RTDB) {
+      col = this.db.child(id);
+      await col.remove();
+    } else {
+      col = this.db.collection(this.dbname).doc(id);
+      await col.delete();
+    }
+
+    // Update the cache
+    this.cache.del(id);
+  }
+
+  /**
+   * Return all keys.
+   * @returns {array} - Array of keys (strings)
+   */
+  async list() {
+    if (this.engine === ENGINE_RTDB) {
+      // firebase RTDB
+      const cols = await this.db.once('value');
+      return cols.ref.sortedDataKeys;
+    } else {
+      // firestore
+      const docs = await this.db.collection(this.dbname).get();
+      let ids = [];
+      docs.forEach(doc => ids.push(doc.id));
+      return ids;
+    }
+  }
 }

--- a/src/server/db/firebase.test.js
+++ b/src/server/db/firebase.test.js
@@ -121,6 +121,28 @@ describe('Firestore', async () => {
     expect(await db.get('gameID')).toMatchObject({ _stateID: 1 });
     expect(db.cache.get('gameID')).toMatchObject({ _stateID: 1 });
   });
+
+  test('list entries', async () => {
+    // Insert 3 entries
+    await db.set('gameID_0', { a: 0 });
+    await db.set('gameID_2', { a: 2 });
+    await db.set('gameID_1', { a: 1 });
+    const ids = await db.list();
+    expect(ids).toContain('gameID_0');
+    expect(ids).toContain('gameID_1');
+    expect(ids).toContain('gameID_2');
+  });
+
+  test('remove entry', async () => {
+    // Insert 2 entries
+    await db.set('gameID_0', { a: 0 });
+    await db.set('gameID_1', { a: 1 });
+    // Remove 1
+    await db.remove('gameID_1');
+    expect(await db.has('gameID_0')).toBe(true);
+    expect(await db.has('gameID_1')).toBe(false);
+    await db.remove('gameID_1');
+  });
 });
 
 describe('RTDB', async () => {
@@ -198,5 +220,27 @@ describe('RTDB', async () => {
     db.cache.reset();
     expect(await db.get('gameID')).toMatchObject({ _stateID: 1 });
     expect(db.cache.get('gameID')).toMatchObject({ _stateID: 1 });
+  });
+
+  test('list entries', async () => {
+    // Insert 3 entries
+    await db.set('gameID_0', { a: 0 });
+    await db.set('gameID_2', { a: 2 });
+    await db.set('gameID_1', { a: 1 });
+    const ids = await db.list();
+    expect(ids).toContain('gameID_0');
+    expect(ids).toContain('gameID_1');
+    expect(ids).toContain('gameID_2');
+  });
+
+  test('remove entry', async () => {
+    // Insert 2 entries
+    await db.set('gameID_0', { a: 0 });
+    await db.set('gameID_1', { a: 1 });
+    // Remove 1
+    await db.remove('gameID_1');
+    expect(await db.has('gameID_0')).toBe(true);
+    expect(await db.has('gameID_1')).toBe(false);
+    await db.remove('gameID_1');
   });
 });

--- a/src/server/db/inmemory.js
+++ b/src/server/db/inmemory.js
@@ -45,11 +45,32 @@ export class InMemory {
   }
 
   /**
+   * Remove the game state from the in-memory object.
+   * @param {string} id - The game id.
+   * @returns {object} - The removed game state, or undefined
+   *                     if no game was found with this id.
+   */
+  async remove(id) {
+    if (!await this.games.has(id)) return;
+    const game = await this.games.get(id);
+    this.games.delete(id);
+    return game;
+  }
+
+  /**
    * Check if a particular game id exists.
    * @param {string} id - The game id.
    * @returns {boolean} - True if a game with this id exists.
    */
   async has(id) {
     return await this.games.has(id);
+  }
+
+  /**
+   * Return all keys.
+   * @returns {array} - Array of keys (strings)
+   */
+  async list() {
+    return Array.from(await this.games.keys());
   }
 }

--- a/src/server/db/inmemory.js
+++ b/src/server/db/inmemory.js
@@ -45,25 +45,21 @@ export class InMemory {
   }
 
   /**
-   * Remove the game state from the in-memory object.
-   * @param {string} id - The game id.
-   * @returns {object} - The removed game state, or undefined
-   *                     if no game was found with this id.
-   */
-  async remove(id) {
-    if (!await this.games.has(id)) return;
-    const game = await this.games.get(id);
-    this.games.delete(id);
-    return game;
-  }
-
-  /**
    * Check if a particular game id exists.
    * @param {string} id - The game id.
    * @returns {boolean} - True if a game with this id exists.
    */
   async has(id) {
     return await this.games.has(id);
+  }
+
+  /**
+   * Remove the game state from the in-memory object.
+   * @param {string} id - The game id.
+   */
+  async remove(id) {
+    if (!await this.games.has(id)) return;
+    this.games.delete(id);
   }
 
   /**

--- a/src/server/db/inmemory.test.js
+++ b/src/server/db/inmemory.test.js
@@ -30,11 +30,9 @@ test('inmemory db', async () => {
   let keys = await db.list();
   expect(keys).toEqual(['gameID']);
 
-  // Must remove game from DB and return it.
-  state = await db.remove('gameID');
-  expect(state).toEqual({ a: 1 });
-  has = await db.has('gameID');
-  expect(has).toEqual(false);
-  state = await db.remove('gameID');
-  expect(state).toEqual(undefined);
+  // Must remove game from DB
+  await db.remove('gameID');
+  expect(await db.has('gameID')).toEqual(false);
+  // Shall not return error
+  await db.remove('gameID');
 });

--- a/src/server/db/inmemory.test.js
+++ b/src/server/db/inmemory.test.js
@@ -23,6 +23,18 @@ test('inmemory db', async () => {
   expect(state).toEqual({ a: 1 });
 
   // Must return true if game exists
-  const has = await db.has('gameID');
+  let has = await db.has('gameID');
   expect(has).toEqual(true);
+
+  // Must return all keys
+  let keys = await db.list();
+  expect(keys).toEqual(['gameID']);
+
+  // Must remove game from DB and return it.
+  state = await db.remove('gameID');
+  expect(state).toEqual({ a: 1 });
+  has = await db.has('gameID');
+  expect(has).toEqual(false);
+  state = await db.remove('gameID');
+  expect(state).toEqual(undefined);
 });

--- a/src/server/db/mongo.js
+++ b/src/server/db/mongo.js
@@ -132,4 +132,31 @@ export class Mongo {
       .toArray();
     return docs.length > 0;
   }
+
+  /**
+   * Remove the game state from the DB.
+   * @param {string} id - The game id.
+   */
+  async remove(id) {
+    if (!await this.has(id)) return;
+
+    function _dropCollection(db, id) {
+      return new Promise(function(ok) {
+        db.dropCollection(id, ok);
+      });
+    }
+    await _dropCollection(this.db, id);
+
+    // Update the cache
+    this.cache.del(id);
+  }
+
+  /**
+   * Return all keys.
+   * @returns {array} - Array of keys (strings)
+   */
+  async list() {
+    const keys = await this.db.listCollections().toArray();
+    return keys.map(r => r.name);
+  }
 }

--- a/src/server/db/mongo.test.js
+++ b/src/server/db/mongo.test.js
@@ -85,3 +85,34 @@ test('Mongo - race conditions', async () => {
   expect(await db.get('gameID')).toMatchObject({ _stateID: 1 });
   expect(db.cache.get('gameID')).toMatchObject({ _stateID: 1 });
 });
+
+test('Mongo - list', async () => {
+  const mockClient = MongoDB.MongoClient;
+  const db = new Mongo({ mockClient, url: 'a' });
+  await db.connect();
+
+  // Insert 3 entries
+  await db.set('gameID_0', { a: 0 });
+  await db.set('gameID_2', { a: 2 });
+  await db.set('gameID_1', { a: 1 });
+  const ids = await db.list();
+  expect(ids).toContain('gameID_0');
+  expect(ids).toContain('gameID_1');
+  expect(ids).toContain('gameID_2');
+});
+
+test('Mongo - remove', async () => {
+  const mockClient = MongoDB.MongoClient;
+  const db = new Mongo({ mockClient, url: 'a' });
+  await db.connect();
+
+  // Insert 2 entries
+  await db.set('gameID_0', { a: 0 });
+  await db.set('gameID_1', { a: 1 });
+  // Remove 1
+  await db.remove('gameID_1');
+  expect(await db.has('gameID_0')).toBe(true);
+  expect(await db.has('gameID_1')).toBe(false);
+  // Shall not throw error
+  await db.remove('gameID_1');
+});


### PR DESCRIPTION
This PR introduces 2 new API endpoints for the future lobby implementation:
 - _list_ allows returning a list of instances for a given game
 - _leave_ is the symmetric of _join_ ; note that after the last player leaves a game instance, it is automatically destroyed

#### Checklist

* [ ] Use a separate branch in your local repo (not `master`).
* [ ] Test coverage is 100% (or you have a story for why it's ok).
